### PR TITLE
feat: 4 板块拆分 + 议程导航 + 退出登录 + @mention

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "./scripts/test.sh",
     "test:watch": "vitest",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
-    "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+    "deploy": "./scripts/deploy.sh",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "dependencies": {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Local manual deploy to Cloudflare Workers. Use only as a fallback when the
+# CF dashboard auto-deploy (Workers Builds → main) is unavailable.
+#
+# Normal flow: merge to main → CF Workers Builds runs build & deploy with
+# NEXT_PUBLIC_* injected from dashboard env vars. No human action needed.
+#
+# This script exists because `next build` inlines NEXT_PUBLIC_* into the
+# bundle at build time. A bare `opennextjs-cloudflare build && deploy` from
+# a shell without those vars ships a bundle where every NEXT_PUBLIC_* is
+# undefined — server actions that touch Supabase then 500 in production.
+#
+# Runtime secrets (EVENT_PASSWORD, SUPABASE_SERVICE_ROLE_KEY, DEEPSEEK_API_KEY)
+# are managed in the Worker via `wrangler secret put` (see scripts/cf-secrets-push.sh)
+# and do not need to be exported here.
+
+set -euo pipefail
+
+if ! command -v secret >/dev/null 2>&1; then
+  echo "ERROR: 'secret' CLI not found. Expected at ~/.local/bin/secret" >&2
+  exit 1
+fi
+
+echo "→ Injecting NEXT_PUBLIC_* from Keychain"
+export NEXT_PUBLIC_SUPABASE_URL="$(secret get supabase-dams-url)"
+export NEXT_PUBLIC_SUPABASE_ANON_KEY="$(secret get supabase-dams-anon)"
+export NEXT_PUBLIC_EVENT_NAME="荷兰华人数据群 Meetup 第14期"
+export NEXT_PUBLIC_EVENT_START="2026-05-09T12:45:00+02:00"
+export NEXT_PUBLIC_EVENT_END="2026-05-09T18:00:00+02:00"
+export NEXT_PUBLIC_EVENT_ORGANIZER="DAMS"
+
+echo "→ Building Worker bundle"
+npx opennextjs-cloudflare build
+
+echo "→ Deploying to meet.zhaidewei.com"
+exec npx opennextjs-cloudflare deploy

--- a/src/app/agenda/page.tsx
+++ b/src/app/agenda/page.tsx
@@ -1,0 +1,20 @@
+import { redirect } from 'next/navigation'
+import { getCurrentUser } from '@/lib/identity'
+import { Header } from '@/components/Header'
+import { Agenda } from '@/components/Agenda'
+
+export const dynamic = 'force-dynamic'
+
+export default async function AgendaPage() {
+  const user = await getCurrentUser()
+  if (!user) redirect('/')
+
+  return (
+    <>
+      <Header active="agenda" />
+      <main className="mx-auto w-full max-w-2xl px-4 py-4">
+        <Agenda />
+      </main>
+    </>
+  )
+}

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -3,36 +3,48 @@ import { getCurrentUser, touchLastSeen } from '@/lib/identity'
 import { Header } from '@/components/Header'
 import { PostComposer } from '@/components/PostComposer'
 import { PostCard } from '@/components/PostCard'
+import { SectionTabs } from '@/components/SectionTabs'
 import { fetchFeed } from '@/lib/queries/posts'
+import { DEFAULT_SECTION, isSectionId } from '@/lib/sections'
 
 export const dynamic = 'force-dynamic'
 
-export default async function FeedPage() {
+type SearchParams = Promise<{ section?: string }>
+
+export default async function FeedPage({ searchParams }: { searchParams: SearchParams }) {
   const user = await getCurrentUser()
   if (!user) redirect('/')
+
+  const sp = await searchParams
+  if (sp.section !== undefined && !isSectionId(sp.section)) {
+    redirect(`/feed?section=${DEFAULT_SECTION}`)
+  }
+  const section = isSectionId(sp.section) ? sp.section : DEFAULT_SECTION
 
   // Mark this user as recently active (used by /screen online count).
   // Fire-and-forget; don't await on the render path.
   void touchLastSeen(user.id)
 
-  const posts = await fetchFeed(user.id)
+  const posts = await fetchFeed(user.id, { section })
 
   return (
     <>
       <Header active="feed" />
       <main className="mx-auto w-full max-w-2xl px-4 py-4">
-        <div className="space-y-4">
+        <SectionTabs active={section} />
+        <div className="mt-4 space-y-4">
           <PostComposer
             defaultNickname={user.nickname}
             defaultCompany={user.company}
             defaultContactHandle={user.contact_handle}
             defaultShowContact={user.show_contact}
             isVip={user.is_vip}
+            section={section}
           />
 
           {posts.length === 0 ? (
             <div className="rounded-xl border border-dashed border-zinc-300 bg-white px-4 py-12 text-center text-sm text-zinc-500">
-              还没有人发帖。第一条由你来。
+              这个板块还没有人发帖。第一条由你来。
             </div>
           ) : (
             <div className="space-y-3">

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -5,6 +5,7 @@ import { Header } from '@/components/Header'
 import { PostCard } from '@/components/PostCard'
 import { ProfileForm } from '@/components/ProfileForm'
 import { RecoveryLink } from '@/components/RecoveryLink'
+import { LogoutButton } from '@/components/LogoutButton'
 import { fetchFeed } from '@/lib/queries/posts'
 import { fetchRepliesToMe, fetchMentionsOfMe, type ReplyToMe, type MentionOfMe } from '@/lib/queries/me'
 
@@ -36,6 +37,8 @@ export default async function MePage() {
           />
 
           <RecoveryLink uid={user.id} token={user.recovery_token} />
+
+          <LogoutButton />
 
           <Section title={`有人想找你 (${mentionsOfMe.length})`}>
             {mentionsOfMe.length === 0 ? (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 import { ensureUser, readPwCookie, setPwCookie } from '@/lib/identity'
 import { EVENT_NAME, EVENT_ORGANIZER } from '@/lib/constants'
+import { Agenda } from '@/components/Agenda'
 
 type SearchParams = Promise<{
   u?: string
@@ -88,107 +89,6 @@ export default async function HomePage({
     </main>
   )
 }
-
-function Agenda() {
-  return (
-    <section aria-label="活动议程" className="space-y-4">
-      <h2 className="text-center text-sm font-medium tracking-wide text-zinc-500">
-        活动议程 · 2026-05-09
-      </h2>
-      <ol className="divide-y divide-zinc-200 rounded-lg border border-zinc-200 bg-white">
-        {AGENDA.map((item) => (
-          <li key={item.time} className="grid grid-cols-[7rem_1fr] gap-4 px-4 py-3 sm:px-5">
-            <span className="text-sm tabular-nums text-zinc-500">{item.time}</span>
-            <div className="space-y-2">
-              <p className="text-sm font-medium text-zinc-900">{item.title}</p>
-              {item.talks && (
-                <ul className="space-y-1.5">
-                  {item.talks.map((t) => (
-                    <li key={t.topic} className="text-sm text-zinc-700">
-                      <span>{t.topic}</span>
-                      <span className="text-zinc-500"> — {t.speaker}，{t.affiliation}</span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-              {item.sponsors && (
-                <ul className="space-y-1 text-sm text-zinc-700">
-                  {item.sponsors.map((s) => (
-                    <li key={s.name}>
-                      <span className="text-zinc-500">{s.label}：</span>
-                      {s.name}
-                    </li>
-                  ))}
-                </ul>
-              )}
-              {item.panelists && (
-                <ul className="space-y-1 text-sm text-zinc-700">
-                  {item.panelists.map((p) => (
-                    <li key={p.name}>
-                      {p.name}
-                      <span className="text-zinc-500">，{p.role}</span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-          </li>
-        ))}
-      </ol>
-    </section>
-  )
-}
-
-type AgendaItem = {
-  time: string
-  title: string
-  talks?: { topic: string; speaker: string; affiliation: string }[]
-  sponsors?: { label: string; name: string }[]
-  panelists?: { name: string; role: string }[]
-}
-
-const AGENDA: AgendaItem[] = [
-  { time: '12:45 – 13:20', title: '签到、领取名牌及欢迎饮品' },
-  { time: '13:20 – 13:30', title: '开场致辞' },
-  {
-    time: '13:30 – 14:30',
-    title: '主题演讲',
-    talks: [
-      {
-        topic: '和 AI 搭档：合作、摩擦与重新定义工作',
-        speaker: '刘爵铭',
-        affiliation: 'Senior Applied Scientist @ Uber',
-      },
-      {
-        topic: 'AI 背景下的技术研究：我们应该和可以干什么',
-        speaker: '杨杰',
-        affiliation: 'Assistant Professor @ TU Delft',
-      },
-    ],
-  },
-  {
-    time: '14:30 – 14:45',
-    title: '赞助商 & 合作协会宣讲',
-    sponsors: [
-      { label: '赞助商', name: '腾讯 (Tencent)' },
-      { label: '合作协会', name: '荷兰华人学者与工程师协会' },
-    ],
-  },
-  { time: '14:45 – 15:30', title: '分组交流 & 茶歇' },
-  {
-    time: '15:30 – 17:20',
-    title: '圆桌讨论：AI 浪潮下数据人何去何从',
-    panelists: [
-      { name: '葛怡', role: 'Project Lead @ ASML' },
-      { name: '张霁', role: 'Founder @ Arboretica' },
-      { name: '杨杰', role: 'Assistant Professor @ TU Delft' },
-      { name: '杨开涛', role: 'VP of Machine Learning @ Epicore Biosystems' },
-      { name: '翟德炜', role: 'Founder @ Dewei Consulting B.V.' },
-      { name: '祖彬', role: 'Senior Manager Demand Planning @ PVH' },
-    ],
-  },
-  { time: '17:20 – 18:00', title: '幸运抽奖、合影、自由社交' },
-]
 
 function safeNext(next: string | undefined) {
   if (typeof next === 'string' && next.startsWith('/') && !next.startsWith('//')) {

--- a/src/app/screen/page.tsx
+++ b/src/app/screen/page.tsx
@@ -5,25 +5,40 @@ import { fetchScreenData } from '@/lib/actions/screen'
 import { QRCode } from '@/components/QRCode'
 import { ScreenView } from '@/components/screen/ScreenView'
 import { EVENT_NAME } from '@/lib/constants'
+import { isSectionId, sectionLabel } from '@/lib/sections'
 
 export const dynamic = 'force-dynamic'
 
-export default async function ScreenPage() {
+type SearchParams = Promise<{ section?: string }>
+
+export default async function ScreenPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
   const user = await getCurrentUser()
   if (!user) redirect('/')
 
-  const [snap, h] = await Promise.all([fetchScreenData(), headers()])
+  const sp = await searchParams
+  const section = isSectionId(sp.section) ? sp.section : null
+
+  const [snap, h] = await Promise.all([fetchScreenData(section), headers()])
 
   const host = h.get('x-forwarded-host') ?? h.get('host') ?? ''
   const proto =
     h.get('x-forwarded-proto') ?? (host.startsWith('localhost') ? 'http' : 'https')
-  const feedUrl = host ? `${proto}://${host}/feed` : '/feed'
+  // QR points to the feed of the same section, so attendees joining mid-talk
+  // land in the right discussion stream.
+  const feedPath = section ? `/feed?section=${section}` : '/feed'
+  const feedUrl = host ? `${proto}://${host}${feedPath}` : feedPath
 
   return (
     <ScreenView
       initialPosts={snap.posts}
       initialOnline={snap.online}
       eventName={EVENT_NAME}
+      section={section}
+      sectionLabel={section ? sectionLabel(section) : null}
       qrSlot={<QRCode value={feedUrl} size={160} />}
     />
   )

--- a/src/components/Agenda.tsx
+++ b/src/components/Agenda.tsx
@@ -1,0 +1,100 @@
+type AgendaItem = {
+  time: string
+  title: string
+  talks?: { topic: string; speaker: string; affiliation: string }[]
+  sponsors?: { label: string; name: string }[]
+  panelists?: { name: string; role: string }[]
+}
+
+const AGENDA: AgendaItem[] = [
+  { time: '12:45 – 13:20', title: '签到、领取名牌及欢迎饮品' },
+  { time: '13:20 – 13:30', title: '开场致辞' },
+  {
+    time: '13:30 – 14:30',
+    title: '主题演讲',
+    talks: [
+      {
+        topic: '和 AI 搭档：合作、摩擦与重新定义工作',
+        speaker: '刘爵铭',
+        affiliation: 'Senior Applied Scientist @ Uber',
+      },
+      {
+        topic: 'AI 背景下的技术研究：我们应该和可以干什么',
+        speaker: '杨杰',
+        affiliation: 'Assistant Professor @ TU Delft',
+      },
+    ],
+  },
+  {
+    time: '14:30 – 14:45',
+    title: '赞助商 & 合作协会宣讲',
+    sponsors: [
+      { label: '赞助商', name: '腾讯 (Tencent)' },
+      { label: '合作协会', name: '荷兰华人学者与工程师协会' },
+    ],
+  },
+  { time: '14:45 – 15:30', title: '分组交流 & 茶歇' },
+  {
+    time: '15:30 – 17:20',
+    title: '圆桌讨论：AI 浪潮下数据人何去何从',
+    panelists: [
+      { name: '葛怡', role: 'Project Lead @ ASML' },
+      { name: '张霁', role: 'Founder @ Arboretica' },
+      { name: '杨杰', role: 'Assistant Professor @ TU Delft' },
+      { name: '杨开涛', role: 'VP of Machine Learning @ Epicore Biosystems' },
+      { name: '翟德炜', role: 'Founder @ Dewei Consulting B.V.' },
+      { name: '祖彬', role: 'Senior Manager Demand Planning @ PVH' },
+    ],
+  },
+  { time: '17:20 – 18:00', title: '幸运抽奖、合影、自由社交' },
+]
+
+export function Agenda() {
+  return (
+    <section aria-label="活动议程" className="space-y-4">
+      <h2 className="text-center text-sm font-medium tracking-wide text-zinc-500">
+        活动议程 · 2026-05-09
+      </h2>
+      <ol className="divide-y divide-zinc-200 rounded-lg border border-zinc-200 bg-white">
+        {AGENDA.map((item) => (
+          <li key={item.time} className="grid grid-cols-[7rem_1fr] gap-4 px-4 py-3 sm:px-5">
+            <span className="text-sm tabular-nums text-zinc-500">{item.time}</span>
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-zinc-900">{item.title}</p>
+              {item.talks && (
+                <ul className="space-y-1.5">
+                  {item.talks.map((t) => (
+                    <li key={t.topic} className="text-sm text-zinc-700">
+                      <span>{t.topic}</span>
+                      <span className="text-zinc-500"> — {t.speaker}，{t.affiliation}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {item.sponsors && (
+                <ul className="space-y-1 text-sm text-zinc-700">
+                  {item.sponsors.map((s) => (
+                    <li key={s.name}>
+                      <span className="text-zinc-500">{s.label}：</span>
+                      {s.name}
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {item.panelists && (
+                <ul className="space-y-1 text-sm text-zinc-700">
+                  {item.panelists.map((p) => (
+                    <li key={p.name}>
+                      {p.name}
+                      <span className="text-zinc-500">，{p.role}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { EVENT_NAME } from '@/lib/constants'
 
 type Props = {
-  active?: 'feed' | 'me'
+  active?: 'feed' | 'agenda' | 'me'
 }
 
 export function Header({ active = 'feed' }: Props) {
@@ -14,6 +14,7 @@ export function Header({ active = 'feed' }: Props) {
         </Link>
         <nav className="flex gap-1 text-sm">
           <NavTab href="/feed" label="时间线" active={active === 'feed'} />
+          <NavTab href="/agenda" label="议程" active={active === 'agenda'} />
           <NavTab href="/me" label="我" active={active === 'me'} />
         </nav>
       </div>

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { logoutAction } from '@/lib/actions/logout'
+
+export function LogoutButton() {
+  const [open, setOpen] = useState(false)
+  const [pending, startTransition] = useTransition()
+
+  function confirm() {
+    try {
+      localStorage.clear()
+      sessionStorage.clear()
+    } catch {
+      // ignore — cookies are the source of truth
+    }
+    startTransition(() => {
+      logoutAction()
+    })
+  }
+
+  return (
+    <>
+      <div className="rounded-xl border border-zinc-200 bg-white p-4 shadow-sm">
+        <h2 className="mb-1 text-sm font-semibold text-zinc-900">退出登录</h2>
+        <p className="mb-3 text-xs text-zinc-500">
+          退出会清除本机的身份缓存。下次进入需要用恢复链接或活动密码。
+        </p>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded-md border border-red-300 bg-white px-3 py-1.5 text-sm text-red-600 hover:bg-red-50"
+        >
+          退出登录
+        </button>
+      </div>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+          onClick={() => !pending && setOpen(false)}
+        >
+          <div
+            className="w-full max-w-sm rounded-xl bg-white p-5 shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="mb-2 text-base font-semibold text-zinc-900">确认退出？</h3>
+            <p className="mb-4 text-sm text-zinc-600">
+              退出会清除本浏览器的 cookie 和本地缓存。
+              <br />
+              <span className="text-red-600">
+                只有保存了「恢复链接」才能找回当前身份与发帖记录。
+              </span>
+              <br />
+              请确认你已经把恢复链接复制保存好。
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                disabled={pending}
+                className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+              >
+                取消
+              </button>
+              <button
+                type="button"
+                onClick={confirm}
+                disabled={pending}
+                className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:bg-red-300"
+              >
+                {pending ? '退出中…' : '已保存，确认退出'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/PollComposer.tsx
+++ b/src/components/PollComposer.tsx
@@ -7,10 +7,17 @@ import {
   POLL_MIN_OPTIONS,
   POST_MAX_CHARS,
 } from '@/lib/constants'
+import type { SectionId } from '@/lib/sections'
 
 const initial: PollFormState = { error: null }
 
-export function PollComposer({ onCancel }: { onCancel: () => void }) {
+export function PollComposer({
+  section,
+  onCancel,
+}: {
+  section: SectionId
+  onCancel: () => void
+}) {
   const [state, formAction] = useActionState(createPollAction, initial)
   const [isPending, startTransition] = useTransition()
   const [body, setBody] = useState('')
@@ -43,6 +50,7 @@ export function PollComposer({ onCancel }: { onCancel: () => void }) {
       onSubmit={onSubmit}
       className="space-y-3 rounded-xl border border-amber-300 bg-amber-50 p-4 shadow-sm"
     >
+      <input type="hidden" name="section" value={section} />
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold text-amber-900">发起投票（嘉宾）</h3>
         <button

--- a/src/components/PostComposer.tsx
+++ b/src/components/PostComposer.tsx
@@ -3,6 +3,7 @@
 import { useActionState, useState, useTransition } from 'react'
 import { createPostAction, type PostFormState } from '@/lib/actions/posts'
 import { POST_MAX_CHARS, MATCH_INTENT_MAX_CHARS } from '@/lib/constants'
+import type { SectionId } from '@/lib/sections'
 import { PollComposer } from './PollComposer'
 
 const initial: PostFormState = { error: null }
@@ -13,6 +14,7 @@ type Props = {
   defaultContactHandle: string | null
   defaultShowContact: boolean
   isVip: boolean
+  section: SectionId
 }
 
 export function PostComposer({
@@ -21,6 +23,7 @@ export function PostComposer({
   defaultContactHandle,
   defaultShowContact,
   isVip,
+  section,
 }: Props) {
   const [state, formAction] = useActionState(createPostAction, initial)
   const [, startTransition] = useTransition()
@@ -31,7 +34,7 @@ export function PostComposer({
   const [mode, setMode] = useState<'text' | 'poll'>('text')
 
   if (mode === 'poll') {
-    return <PollComposer onCancel={() => setMode('text')} />
+    return <PollComposer section={section} onCancel={() => setMode('text')} />
   }
 
   const remaining = POST_MAX_CHARS - body.length
@@ -60,6 +63,7 @@ export function PostComposer({
       onSubmit={onSubmit}
       className="space-y-3 rounded-xl border border-zinc-200 bg-white p-4 shadow-sm"
     >
+      <input type="hidden" name="section" value={section} />
       {isVip && (
         <div className="flex justify-end">
           <button

--- a/src/components/ReplySection.tsx
+++ b/src/components/ReplySection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useActionState, useState, useTransition } from 'react'
+import { useActionState, useRef, useState, useTransition } from 'react'
 import { createReplyAction, type ReplyFormState } from '@/lib/actions/replies'
 import { REPLY_MAX_CHARS } from '@/lib/constants'
 
@@ -32,11 +32,17 @@ type Props = {
   replies: ReplyDisplay[]
 }
 
+function displayName(a: ReplyDisplay['author']): string {
+  if (!a) return '匿名'
+  return a.is_vip ? a.vip_name ?? '嘉宾' : a.nickname ?? '匿名'
+}
+
 export function ReplySection({ postId, count, replies }: Props) {
   const [open, setOpen] = useState(count > 0)
   const [state, formAction] = useActionState(createReplyAction, initial)
   const [, startTransition] = useTransition()
   const [body, setBody] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const remaining = REPLY_MAX_CHARS - body.length
 
@@ -48,6 +54,19 @@ export function ReplySection({ postId, count, replies }: Props) {
       formAction(fd)
     })
     setBody('')
+  }
+
+  function replyTo(name: string) {
+    const mention = `@${name} `
+    setBody((prev) => (prev.startsWith(mention) ? prev : mention + prev.replace(/^@\S+\s+/, '')))
+    setOpen(true)
+    requestAnimationFrame(() => {
+      const el = textareaRef.current
+      if (!el) return
+      el.focus()
+      const len = el.value.length
+      el.setSelectionRange(len, len)
+    })
   }
 
   return (
@@ -65,12 +84,21 @@ export function ReplySection({ postId, count, replies }: Props) {
       {open && (
         <div className="mt-2 space-y-2">
           {replies.map((r) =>
-            r.is_ai ? <AiReplyRow key={r.id} reply={r} /> : <ReplyRow key={r.id} reply={r} />,
+            r.is_ai ? (
+              <AiReplyRow key={r.id} reply={r} />
+            ) : (
+              <ReplyRow
+                key={r.id}
+                reply={r}
+                onReply={() => replyTo(displayName(r.author))}
+              />
+            ),
           )}
 
           <form onSubmit={onSubmit} className="space-y-1">
             <input type="hidden" name="post_id" value={postId} />
             <textarea
+              ref={textareaRef}
               name="body"
               value={body}
               onChange={(e) => setBody(e.target.value)}
@@ -97,10 +125,10 @@ export function ReplySection({ postId, count, replies }: Props) {
   )
 }
 
-function ReplyRow({ reply }: { reply: ReplyDisplay }) {
+function ReplyRow({ reply, onReply }: { reply: ReplyDisplay; onReply: () => void }) {
   const a = reply.author
   if (!a) return null
-  const name = a.is_vip ? a.vip_name ?? '嘉宾' : a.nickname ?? '匿名'
+  const name = displayName(a)
   const meta = a.is_vip ? a.vip_title : a.company
   return (
     <div className="rounded-md bg-zinc-50 px-3 py-2 text-sm">
@@ -112,9 +140,28 @@ function ReplyRow({ reply }: { reply: ReplyDisplay }) {
             嘉宾
           </span>
         )}
+        <button
+          type="button"
+          onClick={onReply}
+          className="ml-auto rounded px-1.5 py-0.5 text-xs text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800"
+        >
+          回复
+        </button>
       </div>
-      <p className="whitespace-pre-wrap text-zinc-800">{reply.body}</p>
+      <ReplyBody body={reply.body} />
     </div>
+  )
+}
+
+function ReplyBody({ body }: { body: string }) {
+  const m = body.match(/^(@\S+)(\s+)([\s\S]*)$/)
+  if (!m) return <p className="whitespace-pre-wrap text-zinc-800">{body}</p>
+  return (
+    <p className="whitespace-pre-wrap text-zinc-800">
+      <span className="font-medium text-sky-700">{m[1]}</span>
+      {m[2]}
+      {m[3]}
+    </p>
   )
 }
 

--- a/src/components/SectionTabs.tsx
+++ b/src/components/SectionTabs.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+import { SECTIONS, type SectionId } from '@/lib/sections'
+
+type Props = {
+  active: SectionId
+}
+
+export function SectionTabs({ active }: Props) {
+  return (
+    <nav
+      aria-label="板块"
+      className="sticky top-[57px] z-20 -mx-4 border-b border-zinc-200 bg-white/95 px-4 py-2 backdrop-blur supports-[backdrop-filter]:bg-white/75"
+    >
+      <ul className="flex gap-1 overflow-x-auto">
+        {SECTIONS.map((s) => {
+          const isActive = s.id === active
+          return (
+            <li key={s.id} className="shrink-0">
+              <Link
+                href={`/feed?section=${s.id}`}
+                aria-current={isActive ? 'page' : undefined}
+                className={
+                  'block rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors ' +
+                  (isActive
+                    ? 'bg-zinc-900 text-white'
+                    : 'bg-zinc-100 text-zinc-700 hover:bg-zinc-200')
+                }
+              >
+                {s.label}
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}

--- a/src/components/screen/ScreenView.tsx
+++ b/src/components/screen/ScreenView.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { FeedPost } from '@/lib/queries/posts'
 import { fetchScreenData } from '@/lib/actions/screen'
+import type { SectionId } from '@/lib/sections'
 
 const POLL_TICK_MS = 1_000 // ui re-render cadence
 const REFRESH_MS = 10_000 // server-data poll cadence
@@ -13,6 +14,8 @@ type Props = {
   initialPosts: FeedPost[]
   initialOnline: number
   eventName: string
+  section: SectionId | null
+  sectionLabel: string | null
   qrSlot: React.ReactNode
 }
 
@@ -20,6 +23,8 @@ export function ScreenView({
   initialPosts,
   initialOnline,
   eventName,
+  section,
+  sectionLabel,
   qrSlot,
 }: Props) {
   const [posts, setPosts] = useState(initialPosts)
@@ -35,7 +40,7 @@ export function ScreenView({
     let cancelled = false
     async function refresh() {
       try {
-        const snap = await fetchScreenData()
+        const snap = await fetchScreenData(section)
         if (cancelled) return
         setPosts(snap.posts)
         setOnline(snap.online)
@@ -48,7 +53,7 @@ export function ScreenView({
       cancelled = true
       clearInterval(id)
     }
-  }, [])
+  }, [section])
 
   const activePolls = useMemo(
     () =>
@@ -74,7 +79,14 @@ export function ScreenView({
   return (
     <div className="flex h-svh w-screen flex-col bg-zinc-950 text-zinc-100">
       <header className="mx-auto flex w-full max-w-[1400px] items-baseline justify-between px-10 py-6 text-zinc-300">
-        <h1 className="text-3xl font-semibold tracking-tight">{eventName}</h1>
+        <div className="flex items-baseline gap-4">
+          <h1 className="text-3xl font-semibold tracking-tight">{eventName}</h1>
+          {sectionLabel && (
+            <span className="rounded-full bg-zinc-800 px-3 py-1 text-base font-medium text-zinc-200">
+              {sectionLabel}
+            </span>
+          )}
+        </div>
         <div className="text-xl tabular-nums">
           在线 <span className="font-semibold text-white">{online}</span> 人
         </div>

--- a/src/lib/actions/logout.ts
+++ b/src/lib/actions/logout.ts
@@ -1,0 +1,9 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { clearAllCookies } from '@/lib/identity'
+
+export async function logoutAction() {
+  await clearAllCookies()
+  redirect('/')
+}

--- a/src/lib/actions/polls.ts
+++ b/src/lib/actions/polls.ts
@@ -11,6 +11,7 @@ import {
   POST_MAX_CHARS,
 } from '@/lib/constants'
 import type { PollOption } from '@/lib/types'
+import { isSectionId } from '@/lib/sections'
 
 export type PollFormState = { error: string | null; ok?: boolean }
 
@@ -46,6 +47,9 @@ export async function createPollAction(
   const multi = formData.get('multi') === 'on'
   const hideResults = formData.get('hide_results') === 'on'
 
+  const sectionRaw = formData.get('section')
+  const section = isSectionId(sectionRaw) ? sectionRaw : null
+
   const sb = getServerSupabase()
   const { error } = await sb.from('posts').insert({
     user_id: user.id,
@@ -53,6 +57,7 @@ export async function createPollAction(
     body,
     tags: [],
     show_contact: false,
+    section,
     poll_options: options,
     poll_multi: multi,
     poll_deadline: EVENT_END_ISO,

--- a/src/lib/actions/posts.ts
+++ b/src/lib/actions/posts.ts
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/identity'
 import { getServerSupabase } from '@/lib/supabase/server'
 import { POST_MAX_CHARS, MATCH_INTENT_MAX_CHARS } from '@/lib/constants'
+import { isSectionId } from '@/lib/sections'
 
 export type PostFormState = { error: string | null; ok?: boolean }
 
@@ -30,6 +31,9 @@ export async function createPostAction(
   }
   const matchIntent = matchIntentRaw.length > 0 ? matchIntentRaw : null
 
+  const sectionRaw = formData.get('section')
+  const section = isSectionId(sectionRaw) ? sectionRaw : null
+
   const sb = getServerSupabase()
 
   // Persist identity updates so the next post auto-fills.
@@ -45,6 +49,7 @@ export async function createPostAction(
     body,
     tags,
     show_contact: showContact,
+    section,
     match_intent: matchIntent,
   })
 

--- a/src/lib/actions/screen.ts
+++ b/src/lib/actions/screen.ts
@@ -2,6 +2,7 @@
 
 import { getServerSupabase } from '@/lib/supabase/server'
 import { fetchFeed, type FeedPost } from '@/lib/queries/posts'
+import { isSectionId, type SectionId } from '@/lib/sections'
 
 // The screen has no viewer identity — using a zero UUID makes liked_by_me /
 // poll_my_vote_options always false in fetchFeed (no row matches).
@@ -14,11 +15,12 @@ export type ScreenSnapshot = {
   serverNow: number
 }
 
-export async function fetchScreenData(): Promise<ScreenSnapshot> {
+export async function fetchScreenData(section?: string | null): Promise<ScreenSnapshot> {
   const sb = getServerSupabase()
   const cutoff = new Date(Date.now() - ONLINE_WINDOW_MS).toISOString()
+  const sectionFilter: SectionId | undefined = isSectionId(section) ? section : undefined
   const [posts, onlineRes] = await Promise.all([
-    fetchFeed(SCREEN_VIEWER_ID, { limit: 50 }),
+    fetchFeed(SCREEN_VIEWER_ID, { limit: 50, section: sectionFilter }),
     sb
       .from('users')
       .select('id', { count: 'exact', head: true })

--- a/src/lib/queries/posts.ts
+++ b/src/lib/queries/posts.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 import { getServerSupabase } from '@/lib/supabase/server'
 import type { PostRow, PublicUserDisplay } from '@/lib/types'
+import type { SectionId } from '@/lib/sections'
 
 type AuthorMini = Pick<
   PublicUserDisplay,
@@ -43,7 +44,7 @@ export type FeedPost = PostRow & {
 
 export async function fetchFeed(
   viewerId: string,
-  opts: { limit?: number; authorId?: string } = {},
+  opts: { limit?: number; authorId?: string; section?: SectionId } = {},
 ): Promise<FeedPost[]> {
   const sb = getServerSupabase()
   const limit = opts.limit ?? 100
@@ -51,7 +52,7 @@ export async function fetchFeed(
   let postsQuery = sb
     .from('posts')
     .select(
-      `id, user_id, type, body, tags, show_contact,
+      `id, user_id, type, body, tags, show_contact, section,
        poll_options, poll_multi, poll_deadline, poll_hide_results,
        match_intent, created_at,
        author:users!user_id ( nickname, company, contact_handle, is_vip, vip_name, vip_title ),
@@ -65,6 +66,7 @@ export async function fetchFeed(
     .limit(limit)
 
   if (opts.authorId) postsQuery = postsQuery.eq('user_id', opts.authorId)
+  if (opts.section) postsQuery = postsQuery.eq('section', opts.section)
 
   const [postsRes, likesRes, votesRes] = await Promise.all([
     postsQuery,

--- a/src/lib/sections.ts
+++ b/src/lib/sections.ts
@@ -1,0 +1,23 @@
+// 4 event sections — splits the timeline into separate discussion streams.
+// Backend stores `posts.section` (text, nullable). Constraint in 0005.
+
+export const SECTIONS = [
+  { id: 'p1', label: '演讲 1' },
+  { id: 'p2', label: '演讲 2' },
+  { id: 'breakout', label: '分组交流' },
+  { id: 'panel', label: '圆桌讨论' },
+] as const
+
+export type SectionId = (typeof SECTIONS)[number]['id']
+
+export const DEFAULT_SECTION: SectionId = 'p1'
+
+const SECTION_IDS = SECTIONS.map((s) => s.id) as readonly string[]
+
+export function isSectionId(value: unknown): value is SectionId {
+  return typeof value === 'string' && SECTION_IDS.includes(value)
+}
+
+export function sectionLabel(id: SectionId): string {
+  return SECTIONS.find((s) => s.id === id)!.label
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,7 @@ export type PostRow = {
   body: string
   tags: string[]
   show_contact: boolean
+  section: 'p1' | 'p2' | 'breakout' | 'panel' | null
   poll_options: PollOption[] | null
   poll_multi: boolean | null
   poll_deadline: string | null

--- a/supabase/migrations/0005_post_sections.sql
+++ b/supabase/migrations/0005_post_sections.sql
@@ -1,0 +1,19 @@
+-- =====================================================================
+-- 0005_post_sections.sql — split timeline into 4 event sections
+-- =====================================================================
+-- p1: 演讲 1 (刘爵铭, 13:30-14:00)
+-- p2: 演讲 2 (杨杰,   14:00-14:30)
+-- breakout: 分组交流 (14:45-15:30)
+-- panel:    圆桌讨论 (15:30-17:20)
+-- NULL: legacy posts created before this migration (won't show in any tab,
+--       but still visible on /me and on /screen when no ?section= filter).
+
+alter table posts add column section text;
+
+alter table posts
+  add constraint posts_section_check
+  check (section is null or section in ('p1', 'p2', 'breakout', 'panel'));
+
+create index posts_section_created_idx
+  on posts (section, created_at desc)
+  where section is not null;


### PR DESCRIPTION
本 PR 合并 5 个独立功能，每个一个 commit，可独立审查。

## Summary

| Commit | 改动 |
|---|---|
| `feat: 加 /agenda 路由 + Header 议程导航` | 议程从只在密码门可见 → header 加 "议程" tab，登录后任意页面可达 |
| `chore: 本地 deploy 脚本注入 NEXT_PUBLIC_*` | 修上次手动 deploy 把 NEXT_PUBLIC_* 编进 bundle 为空的坑；`npm run deploy` 改走 `scripts/deploy.sh` |
| `feat: feed 拆 4 板块 + screen 按板块投影` | 演讲 1 / 演讲 2 / 分组交流 / 圆桌讨论；`/feed?section=<id>` 4 chip tab；composer 跟当前 tab 自动带 section；`/screen?section=<id>` 切单板块 |
| `feat: 退出登录按钮（清 cookie + 本地缓存）` | /me 加二次确认 modal → `logoutAction` 清 cookie + storage |
| `feat: 回复支持 @mention 楼上` | 点回复按钮自动填 "@<对方> " 到 textarea |

## 关键设计决策（板块）

- **Schema**：新加 `posts.section text` 列（带 check constraint），不复用 `posts.tags`。原因：tags 是用户自由输入，section 是固定 4 个，混用会让前端过滤变脏。
- **Composer**：跟当前 tab 自动决定 section，用户不用多选一步。
- **Screen 切板块**：URL 参数 `/screen?section=<id>`，主办方在投影机上手动切；无参数沿用旧"全部"行为兼容。
- **历史帖子**：`section IS NULL`，不会出现在任何 tab，但仍出现在 `/me` 我的帖子和 `/screen` 不带参数时。

## ⚠️ 部署前必做：手工应用 migration 0005

否则带 `section` 字段的代码会在 Supabase 端报 column 不存在。在 Supabase SQL Editor 跑：

```sql
alter table posts add column section text;
alter table posts
  add constraint posts_section_check
  check (section is null or section in ('p1', 'p2', 'breakout', 'panel'));
create index posts_section_created_idx
  on posts (section, created_at desc)
  where section is not null;
```

或直接跑 `supabase/migrations/0005_post_sections.sql`。

可选：把现有测试帖子归到 p1：`update posts set section = 'p1' where section is null;`

## Test plan

- [x] `tsc --noEmit` 通过
- [x] `eslint src` 通过
- [x] `vitest` 9/9 通过
- [x] 本地 dev 验过（用户确认）
- [ ] migration 0005 应用到 Supabase（部署前）
- [ ] CF auto-deploy 后 production 验：议程 tab 可达、4 板块切换正确、composer 发到对应 section、`/screen?section=p1` 显示板块名

🤖 Generated with [Claude Code](https://claude.com/claude-code)