### PR TITLE
feat: 嘉宾名覆盖 / 回复编辑删除 / 嵌套回复

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -39,6 +39,8 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
             defaultContactHandle={user.contact_handle}
             defaultShowContact={user.show_contact}
             isVip={user.is_vip}
+            vipName={user.vip_name}
+            vipTitle={user.vip_title}
             section={section}
           />
 

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -51,7 +51,7 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
           ) : (
             <div className="space-y-3">
               {posts.map((post) => (
-                <PostCard key={post.id} post={post} />
+                <PostCard key={post.id} post={post} viewerId={user.id} />
               ))}
             </div>
           )}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -8,6 +8,7 @@ import { RecoveryLink } from '@/components/RecoveryLink'
 import { LogoutButton } from '@/components/LogoutButton'
 import { fetchFeed } from '@/lib/queries/posts'
 import { fetchRepliesToMe, fetchMentionsOfMe, type ReplyToMe, type MentionOfMe } from '@/lib/queries/me'
+import { displayName, displayMeta } from '@/lib/display'
 
 export const dynamic = 'force-dynamic'
 
@@ -118,8 +119,8 @@ function MentionRow({ mention }: { mention: MentionOfMe }) {
 
 function ReplyToMeRow({ reply }: { reply: ReplyToMe }) {
   const a = reply.replier
-  const name = a.is_vip ? a.vip_name ?? '嘉宾' : a.nickname ?? '匿名'
-  const meta = a.is_vip ? a.vip_title : a.company
+  const name = displayName(a)
+  const meta = displayMeta(a)
   return (
     <Link
       href={`/feed#post-${reply.post_id}`}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -71,7 +71,7 @@ export default async function MePage() {
             ) : (
               <div className="space-y-3">
                 {myPosts.map((post) => (
-                  <PostCard key={post.id} post={post} />
+                  <PostCard key={post.id} post={post} viewerId={user.id} />
                 ))}
               </div>
             )}

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,4 +1,5 @@
 import type { FeedPost } from '@/lib/queries/posts'
+import { displayName, displayMeta } from '@/lib/display'
 import { LikeButton } from './LikeButton'
 import { PollCard } from './PollCard'
 import { ReplySection } from './ReplySection'
@@ -7,17 +8,15 @@ type Props = { post: FeedPost }
 
 export function PostCard({ post }: Props) {
   const author = post.author
-  const displayName = author.is_vip
-    ? author.vip_name ?? '嘉宾'
-    : author.nickname ?? '匿名'
-  const displayMeta = author.is_vip ? author.vip_title : author.company
+  const name = displayName(author)
+  const meta = displayMeta(author)
   const isPoll = post.type === 'poll'
 
   return (
     <article id={`post-${post.id}`} className="scroll-mt-20 rounded-xl border border-zinc-200 bg-white p-4 shadow-sm">
       <header className="mb-2 flex items-baseline gap-2 text-sm">
-        <span className="font-semibold text-zinc-900">{displayName}</span>
-        {displayMeta && <span className="text-zinc-500">· {displayMeta}</span>}
+        <span className="font-semibold text-zinc-900">{name}</span>
+        {meta && <span className="text-zinc-500">· {meta}</span>}
         {author.is_vip && (
           <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800">
             嘉宾

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -4,9 +4,9 @@ import { LikeButton } from './LikeButton'
 import { PollCard } from './PollCard'
 import { ReplySection } from './ReplySection'
 
-type Props = { post: FeedPost }
+type Props = { post: FeedPost; viewerId: string }
 
-export function PostCard({ post }: Props) {
+export function PostCard({ post, viewerId }: Props) {
   const author = post.author
   const name = displayName(author)
   const meta = displayMeta(author)
@@ -70,7 +70,7 @@ export function PostCard({ post }: Props) {
         <LikeButton postId={post.id} count={post.like_count} liked={post.liked_by_me} />
       </div>
 
-      <ReplySection postId={post.id} count={post.reply_count} replies={post.replies} />
+      <ReplySection postId={post.id} count={post.reply_count} replies={post.replies} viewerId={viewerId} />
     </article>
   )
 }

--- a/src/components/PostComposer.tsx
+++ b/src/components/PostComposer.tsx
@@ -4,6 +4,7 @@ import { useActionState, useState, useTransition } from 'react'
 import { createPostAction, type PostFormState } from '@/lib/actions/posts'
 import { POST_MAX_CHARS, MATCH_INTENT_MAX_CHARS } from '@/lib/constants'
 import type { SectionId } from '@/lib/sections'
+import { displayName, displayMeta } from '@/lib/display'
 import { PollComposer } from './PollComposer'
 
 const initial: PostFormState = { error: null }
@@ -14,6 +15,8 @@ type Props = {
   defaultContactHandle: string | null
   defaultShowContact: boolean
   isVip: boolean
+  vipName: string | null
+  vipTitle: string | null
   section: SectionId
 }
 
@@ -23,6 +26,8 @@ export function PostComposer({
   defaultContactHandle,
   defaultShowContact,
   isVip,
+  vipName,
+  vipTitle,
   section,
 }: Props) {
   const [state, formAction] = useActionState(createPostAction, initial)
@@ -55,8 +60,16 @@ export function PostComposer({
 
   const matchRemaining = MATCH_INTENT_MAX_CHARS - matchIntent.length
 
-  const displayName = defaultNickname || '匿名'
-  const displayCompany = defaultCompany ? ` · ${defaultCompany}` : ''
+  const previewUser = {
+    nickname: defaultNickname,
+    company: defaultCompany,
+    is_vip: isVip,
+    vip_name: vipName,
+    vip_title: vipTitle,
+  }
+  const previewName = displayName(previewUser)
+  const previewMeta = displayMeta(previewUser)
+  const displayCompanyLine = previewMeta ? ` · ${previewMeta}` : ''
 
   return (
     <form
@@ -98,8 +111,8 @@ export function PostComposer({
           onClick={() => setIdentityOpen((v) => !v)}
           className="flex items-center gap-1 rounded-md px-2 py-1 hover:bg-zinc-100"
         >
-          <span className="font-medium text-zinc-700">{displayName}</span>
-          <span>{displayCompany}</span>
+          <span className="font-medium text-zinc-700">{previewName}</span>
+          <span>{displayCompanyLine}</span>
           <span className="text-zinc-400">{identityOpen ? '收起' : '编辑身份'}</span>
         </button>
         <span className={remaining < 0 ? 'text-red-500' : ''}>{remaining}</span>

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -42,13 +42,13 @@ export function ProfileForm({
 
       {isVip && (
         <div className="rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-800">
-          嘉宾身份：发帖时显示为 <span className="font-medium">{vipName}</span>
-          {vipTitle && ` · ${vipTitle}`}
+          嘉宾默认显示 <span className="font-medium">{vipName}</span>
+          {vipTitle && ` · ${vipTitle}`}。下方填昵称 / 公司可覆盖默认。
         </div>
       )}
 
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        <Field label="昵称（留空显示为匿名）">
+        <Field label={isVip ? '昵称（留空用嘉宾默认名）' : '昵称（留空显示为匿名）'}>
           <input
             name="nickname"
             defaultValue={defaultNickname ?? ''}
@@ -56,7 +56,7 @@ export function ProfileForm({
             className="w-full rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 focus:outline-none focus:ring-1 focus:ring-zinc-400"
           />
         </Field>
-        <Field label="公司">
+        <Field label={isVip ? '公司（留空用嘉宾默认 title）' : '公司'}>
           <input
             name="company"
             defaultValue={defaultCompany ?? ''}

--- a/src/components/ReplySection.tsx
+++ b/src/components/ReplySection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useActionState, useRef, useState, useTransition } from 'react'
+import { useActionState, useMemo, useRef, useState, useTransition } from 'react'
 import {
   createReplyAction,
   deleteReplyAction,
@@ -15,6 +15,7 @@ const initial: ReplyFormState = { error: null }
 export type ReplyDisplay = {
   id: number
   user_id: string | null
+  parent_reply_id: number | null
   body: string
   created_at: string
   updated_at: string | null
@@ -51,9 +52,25 @@ export function ReplySection({ postId, count, replies, viewerId }: Props) {
   const [state, formAction] = useActionState(createReplyAction, initial)
   const [, startTransition] = useTransition()
   const [body, setBody] = useState('')
+  const [replyingTo, setReplyingTo] = useState<{ id: number; name: string } | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const remaining = REPLY_MAX_CHARS - body.length
+
+  const { topLevel, childrenByParent } = useMemo(() => {
+    const top: ReplyDisplay[] = []
+    const childMap = new Map<number, ReplyDisplay[]>()
+    for (const r of replies) {
+      if (r.parent_reply_id === null) {
+        top.push(r)
+      } else {
+        const arr = childMap.get(r.parent_reply_id) ?? []
+        arr.push(r)
+        childMap.set(r.parent_reply_id, arr)
+      }
+    }
+    return { topLevel: top, childrenByParent: childMap }
+  }, [replies])
 
   function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -63,9 +80,11 @@ export function ReplySection({ postId, count, replies, viewerId }: Props) {
       formAction(fd)
     })
     setBody('')
+    setReplyingTo(null)
   }
 
-  function replyTo(name: string) {
+  function onReplyTo(id: number, name: string) {
+    setReplyingTo({ id, name })
     const mention = `@${name} `
     setBody((prev) => (prev.startsWith(mention) ? prev : mention + prev.replace(/^@\S+\s+/, '')))
     setOpen(true)
@@ -76,6 +95,12 @@ export function ReplySection({ postId, count, replies, viewerId }: Props) {
       const len = el.value.length
       el.setSelectionRange(len, len)
     })
+  }
+
+  function onCancelReplyingTo() {
+    setReplyingTo(null)
+    // Strip leading @mention from textarea since the user explicitly cancelled.
+    setBody((prev) => prev.replace(/^@\S+\s+/, ''))
   }
 
   return (
@@ -92,21 +117,53 @@ export function ReplySection({ postId, count, replies, viewerId }: Props) {
 
       {open && (
         <div className="mt-2 space-y-2">
-          {replies.map((r) =>
-            r.is_ai ? (
-              <AiReplyRow key={r.id} reply={r} />
-            ) : (
-              <ReplyRow
-                key={r.id}
-                reply={r}
-                viewerId={viewerId}
-                onReply={() => replyTo(nameOf(r.author))}
-              />
-            ),
-          )}
+          {topLevel.map((parent) => {
+            const children = childrenByParent.get(parent.id) ?? []
+            return (
+              <div key={parent.id} className="space-y-2">
+                {parent.is_ai ? (
+                  <AiReplyRow reply={parent} />
+                ) : (
+                  <ReplyRow
+                    reply={parent}
+                    viewerId={viewerId}
+                    onReply={() => onReplyTo(parent.id, nameOf(parent.author))}
+                  />
+                )}
+                {children.length > 0 && (
+                  <div className="ml-3 space-y-2 border-l-2 border-zinc-200 pl-3">
+                    {children.map((child) => (
+                      <ReplyRow
+                        key={child.id}
+                        reply={child}
+                        viewerId={viewerId}
+                        onReply={() => onReplyTo(child.id, nameOf(child.author))}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
+          })}
 
           <form onSubmit={onSubmit} className="space-y-1">
             <input type="hidden" name="post_id" value={postId} />
+            <input type="hidden" name="parent_reply_id" value={replyingTo?.id ?? ''} />
+            {replyingTo && (
+              <div className="flex items-center justify-between rounded-md bg-sky-50 px-2 py-1 text-xs text-sky-800">
+                <span>
+                  正在回复 <span className="font-medium">@{replyingTo.name}</span>
+                </span>
+                <button
+                  type="button"
+                  onClick={onCancelReplyingTo}
+                  className="rounded px-1.5 py-0.5 text-sky-700 hover:bg-sky-100"
+                  aria-label="取消回复对象"
+                >
+                  ✕
+                </button>
+              </div>
+            )}
             <textarea
               ref={textareaRef}
               name="body"

--- a/src/components/ReplySection.tsx
+++ b/src/components/ReplySection.tsx
@@ -3,6 +3,7 @@
 import { useActionState, useRef, useState, useTransition } from 'react'
 import { createReplyAction, type ReplyFormState } from '@/lib/actions/replies'
 import { REPLY_MAX_CHARS } from '@/lib/constants'
+import { displayName, displayMeta } from '@/lib/display'
 
 const initial: ReplyFormState = { error: null }
 
@@ -32,9 +33,9 @@ type Props = {
   replies: ReplyDisplay[]
 }
 
-function displayName(a: ReplyDisplay['author']): string {
+function nameOf(a: ReplyDisplay['author']): string {
   if (!a) return '匿名'
-  return a.is_vip ? a.vip_name ?? '嘉宾' : a.nickname ?? '匿名'
+  return displayName(a)
 }
 
 export function ReplySection({ postId, count, replies }: Props) {
@@ -90,7 +91,7 @@ export function ReplySection({ postId, count, replies }: Props) {
               <ReplyRow
                 key={r.id}
                 reply={r}
-                onReply={() => replyTo(displayName(r.author))}
+                onReply={() => replyTo(nameOf(r.author))}
               />
             ),
           )}
@@ -129,7 +130,7 @@ function ReplyRow({ reply, onReply }: { reply: ReplyDisplay; onReply: () => void
   const a = reply.author
   if (!a) return null
   const name = displayName(a)
-  const meta = a.is_vip ? a.vip_title : a.company
+  const meta = displayMeta(a)
   return (
     <div className="rounded-md bg-zinc-50 px-3 py-2 text-sm">
       <div className="mb-0.5 flex items-baseline gap-2 text-xs">
@@ -167,11 +168,7 @@ function ReplyBody({ body }: { body: string }) {
 
 function AiReplyRow({ reply }: { reply: ReplyDisplay }) {
   const m = reply.mentioned_user
-  const targetName = m
-    ? m.is_vip
-      ? m.vip_name ?? '嘉宾'
-      : m.nickname ?? '匿名'
-    : null
+  const targetName = m ? displayName(m) : null
   return (
     <div className="rounded-md border border-sky-200 bg-sky-50 px-3 py-2 text-sm">
       <div className="mb-1 flex items-baseline gap-2 text-xs">

--- a/src/components/ReplySection.tsx
+++ b/src/components/ReplySection.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import { useActionState, useRef, useState, useTransition } from 'react'
-import { createReplyAction, type ReplyFormState } from '@/lib/actions/replies'
+import {
+  createReplyAction,
+  deleteReplyAction,
+  updateReplyAction,
+  type ReplyFormState,
+} from '@/lib/actions/replies'
 import { REPLY_MAX_CHARS } from '@/lib/constants'
 import { displayName, displayMeta } from '@/lib/display'
 
@@ -9,8 +14,10 @@ const initial: ReplyFormState = { error: null }
 
 export type ReplyDisplay = {
   id: number
+  user_id: string | null
   body: string
   created_at: string
+  updated_at: string | null
   is_ai: boolean
   author: {
     nickname: string | null
@@ -31,6 +38,7 @@ type Props = {
   postId: number
   count: number
   replies: ReplyDisplay[]
+  viewerId: string
 }
 
 function nameOf(a: ReplyDisplay['author']): string {
@@ -38,7 +46,7 @@ function nameOf(a: ReplyDisplay['author']): string {
   return displayName(a)
 }
 
-export function ReplySection({ postId, count, replies }: Props) {
+export function ReplySection({ postId, count, replies, viewerId }: Props) {
   const [open, setOpen] = useState(count > 0)
   const [state, formAction] = useActionState(createReplyAction, initial)
   const [, startTransition] = useTransition()
@@ -91,6 +99,7 @@ export function ReplySection({ postId, count, replies }: Props) {
               <ReplyRow
                 key={r.id}
                 reply={r}
+                viewerId={viewerId}
                 onReply={() => replyTo(nameOf(r.author))}
               />
             ),
@@ -126,11 +135,62 @@ export function ReplySection({ postId, count, replies }: Props) {
   )
 }
 
-function ReplyRow({ reply, onReply }: { reply: ReplyDisplay; onReply: () => void }) {
+function ReplyRow({
+  reply,
+  viewerId,
+  onReply,
+}: {
+  reply: ReplyDisplay
+  viewerId: string
+  onReply: () => void
+}) {
   const a = reply.author
+  const [editing, setEditing] = useState(false)
+  const [editBody, setEditBody] = useState(reply.body)
+  const [pending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
   if (!a) return null
   const name = displayName(a)
   const meta = displayMeta(a)
+  const isMine = reply.user_id !== null && reply.user_id === viewerId
+  const editRemaining = REPLY_MAX_CHARS - editBody.length
+
+  function onSaveEdit() {
+    const trimmed = editBody.trim()
+    if (!trimmed) {
+      setError('回复不能为空')
+      return
+    }
+    if (trimmed.length > REPLY_MAX_CHARS) {
+      setError(`不能超过 ${REPLY_MAX_CHARS} 字`)
+      return
+    }
+    startTransition(async () => {
+      const res = await updateReplyAction(reply.id, trimmed)
+      if (res.error) {
+        setError(res.error)
+      } else {
+        setError(null)
+        setEditing(false)
+      }
+    })
+  }
+
+  function onCancelEdit() {
+    setEditing(false)
+    setError(null)
+    setEditBody(reply.body)
+  }
+
+  function onDelete() {
+    if (!window.confirm('删除这条回复？')) return
+    startTransition(async () => {
+      const res = await deleteReplyAction(reply.id)
+      if (res.error) setError(res.error)
+    })
+  }
+
   return (
     <div className="rounded-md bg-zinc-50 px-3 py-2 text-sm">
       <div className="mb-0.5 flex items-baseline gap-2 text-xs">
@@ -141,15 +201,77 @@ function ReplyRow({ reply, onReply }: { reply: ReplyDisplay; onReply: () => void
             嘉宾
           </span>
         )}
-        <button
-          type="button"
-          onClick={onReply}
-          className="ml-auto rounded px-1.5 py-0.5 text-xs text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800"
-        >
-          回复
-        </button>
+        {reply.updated_at && <span className="text-zinc-400">已编辑</span>}
+        <div className="ml-auto flex items-center gap-1">
+          {!editing && (
+            <button
+              type="button"
+              onClick={onReply}
+              className="rounded px-1.5 py-0.5 text-xs text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800"
+            >
+              回复
+            </button>
+          )}
+          {!editing && isMine && (
+            <>
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                className="rounded px-1.5 py-0.5 text-xs text-zinc-500 hover:bg-zinc-200 hover:text-zinc-800"
+              >
+                编辑
+              </button>
+              <button
+                type="button"
+                onClick={onDelete}
+                disabled={pending}
+                className="rounded px-1.5 py-0.5 text-xs text-red-500 hover:bg-red-50 hover:text-red-700 disabled:opacity-50"
+              >
+                删除
+              </button>
+            </>
+          )}
+        </div>
       </div>
-      <ReplyBody body={reply.body} />
+
+      {editing ? (
+        <div className="space-y-1">
+          <textarea
+            value={editBody}
+            onChange={(e) => setEditBody(e.target.value)}
+            maxLength={REPLY_MAX_CHARS}
+            rows={2}
+            className="w-full resize-none rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm focus:border-zinc-400 focus:outline-none"
+          />
+          <div className="flex items-center justify-between text-xs text-zinc-400">
+            <span className={editRemaining < 0 ? 'text-red-500' : ''}>
+              {editRemaining < 0 ? editRemaining : ''}
+            </span>
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={onCancelEdit}
+                disabled={pending}
+                className="rounded-md px-2 py-0.5 text-xs text-zinc-500 hover:bg-zinc-200 disabled:opacity-50"
+              >
+                取消
+              </button>
+              <button
+                type="button"
+                onClick={onSaveEdit}
+                disabled={pending || editBody.trim().length === 0 || editRemaining < 0}
+                className="rounded-md bg-zinc-900 px-2.5 py-0.5 text-xs font-medium text-white hover:bg-zinc-800 disabled:bg-zinc-300"
+              >
+                {pending ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <ReplyBody body={reply.body} />
+      )}
+
+      {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
     </div>
   )
 }

--- a/src/components/screen/ScreenView.tsx
+++ b/src/components/screen/ScreenView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import type { FeedPost } from '@/lib/queries/posts'
 import { fetchScreenData } from '@/lib/actions/screen'
 import type { SectionId } from '@/lib/sections'
+import { displayName, displayMeta } from '@/lib/display'
 
 const POLL_TICK_MS = 1_000 // ui re-render cadence
 const REFRESH_MS = 10_000 // server-data poll cadence
@@ -245,8 +246,8 @@ function PostHeader({
   compact?: boolean
 }) {
   const a = post.author
-  const name = a.is_vip ? a.vip_name ?? '嘉宾' : a.nickname ?? '匿名'
-  const meta = a.is_vip ? a.vip_title : a.company
+  const name = displayName(a)
+  const meta = displayMeta(a)
   const sizeName = large ? 'text-2xl' : compact ? 'text-base' : 'text-xl'
   const sizeMeta = large ? 'text-lg' : 'text-sm'
   return (

--- a/src/lib/actions/replies.ts
+++ b/src/lib/actions/replies.ts
@@ -22,10 +22,34 @@ export async function createReplyAction(
   if (!body) return { error: '回复不能为空' }
   if (body.length > REPLY_MAX_CHARS) return { error: `不能超过 ${REPLY_MAX_CHARS} 字` }
 
+  const parentRaw = formData.get('parent_reply_id')
+  let parentReplyId: number | null = null
+  if (parentRaw !== null && parentRaw !== '') {
+    const n = Number(parentRaw)
+    if (!Number.isInteger(n) || n <= 0) return { error: '回复 parent id 不对' }
+    parentReplyId = n
+  }
+
   const sb = getServerSupabase()
+
+  // One-level nesting: if the parent itself has a parent, flatten to the
+  // grandparent (= the top-level reply of this thread). This means children
+  // never gain children — same thread, same depth.
+  if (parentReplyId !== null) {
+    const { data: parent, error: pErr } = await sb
+      .from('replies')
+      .select('id, post_id, parent_reply_id')
+      .eq('id', parentReplyId)
+      .maybeSingle()
+    if (pErr) return { error: pErr.message }
+    if (!parent) return { error: '父回复不存在' }
+    if (parent.post_id !== postId) return { error: '父回复不属于这个帖子' }
+    parentReplyId = parent.parent_reply_id ?? parent.id
+  }
+
   const { error } = await sb
     .from('replies')
-    .insert({ user_id: user.id, post_id: postId, body })
+    .insert({ user_id: user.id, post_id: postId, body, parent_reply_id: parentReplyId })
 
   if (error) return { error: error.message }
 

--- a/src/lib/actions/replies.ts
+++ b/src/lib/actions/replies.ts
@@ -7,6 +7,7 @@ import { getServerSupabase } from '@/lib/supabase/server'
 import { REPLY_MAX_CHARS } from '@/lib/constants'
 
 export type ReplyFormState = { error: string | null; ok?: boolean }
+export type ReplyMutationResult = { error: string | null }
 
 export async function createReplyAction(
   _prev: ReplyFormState,
@@ -30,4 +31,61 @@ export async function createReplyAction(
 
   revalidatePath('/feed')
   return { error: null, ok: true }
+}
+
+// Authorize-by-filter: .eq('user_id', user.id) means a non-owner update
+// affects 0 rows (data === null). AI replies (user_id IS NULL) are
+// implicitly excluded — they never match a real uid.
+export async function updateReplyAction(
+  replyId: number,
+  body: string,
+): Promise<ReplyMutationResult> {
+  const user = await getCurrentUser()
+  if (!user) redirect('/')
+
+  if (!Number.isInteger(replyId) || replyId <= 0) return { error: '回复 id 不对' }
+  const trimmed = String(body ?? '').trim()
+  if (!trimmed) return { error: '回复不能为空' }
+  if (trimmed.length > REPLY_MAX_CHARS) return { error: `不能超过 ${REPLY_MAX_CHARS} 字` }
+
+  const sb = getServerSupabase()
+  const { data, error } = await sb
+    .from('replies')
+    .update({ body: trimmed, updated_at: new Date().toISOString() })
+    .eq('id', replyId)
+    .eq('user_id', user.id)
+    .select('id')
+    .maybeSingle()
+
+  if (error) return { error: error.message }
+  if (!data) return { error: '没找到这条回复，或者它不是你的' }
+
+  revalidatePath('/feed')
+  revalidatePath('/me')
+  return { error: null }
+}
+
+export async function deleteReplyAction(
+  replyId: number,
+): Promise<ReplyMutationResult> {
+  const user = await getCurrentUser()
+  if (!user) redirect('/')
+
+  if (!Number.isInteger(replyId) || replyId <= 0) return { error: '回复 id 不对' }
+
+  const sb = getServerSupabase()
+  const { data, error } = await sb
+    .from('replies')
+    .delete()
+    .eq('id', replyId)
+    .eq('user_id', user.id)
+    .select('id')
+    .maybeSingle()
+
+  if (error) return { error: error.message }
+  if (!data) return { error: '没找到这条回复，或者它不是你的' }
+
+  revalidatePath('/feed')
+  revalidatePath('/me')
+  return { error: null }
 }

--- a/src/lib/display.ts
+++ b/src/lib/display.ts
@@ -1,0 +1,24 @@
+// Single source of truth for how a user's name + meta render in posts/replies.
+//
+// VIP self-edited nickname/company override the organizer-preset
+// vip_name/vip_title. If a VIP leaves nickname/company blank, we fall back
+// to the preset. Non-VIP users: nickname or "匿名"; company or null.
+//
+// The shape is structural so it matches PostAuthor / ReplyAuthorMini /
+// MentionAuthor without forcing every call site to import the same type.
+
+export type DisplayUser = {
+  nickname: string | null
+  company?: string | null
+  is_vip: boolean
+  vip_name: string | null
+  vip_title?: string | null
+}
+
+export function displayName(u: DisplayUser): string {
+  return u.nickname ?? (u.is_vip ? u.vip_name ?? '嘉宾' : '匿名')
+}
+
+export function displayMeta(u: DisplayUser): string | null {
+  return u.company ?? (u.is_vip ? u.vip_title ?? null : null)
+}

--- a/src/lib/queries/posts.ts
+++ b/src/lib/queries/posts.ts
@@ -24,6 +24,7 @@ export type MentionedUserMini = Pick<
 export type FeedReply = {
   id: number
   user_id: string | null
+  parent_reply_id: number | null
   body: string
   created_at: string
   updated_at: string | null
@@ -59,7 +60,7 @@ export async function fetchFeed(
        match_intent, created_at,
        author:users!user_id ( nickname, company, contact_handle, is_vip, vip_name, vip_title ),
        replies (
-         id, user_id, body, created_at, updated_at, is_ai, visibility, mentioned_user_id,
+         id, user_id, parent_reply_id, body, created_at, updated_at, is_ai, visibility, mentioned_user_id,
          author:users!user_id ( nickname, company, is_vip, vip_name, vip_title ),
          mentioned_user:users!mentioned_user_id ( id, nickname, is_vip, vip_name )
        )`,
@@ -118,6 +119,7 @@ export async function fetchFeed(
     const repliesRaw = (row.replies ?? []) as Array<{
       id: number
       user_id: string | null
+      parent_reply_id: number | null
       body: string
       created_at: string
       updated_at: string | null
@@ -134,6 +136,7 @@ export async function fetchFeed(
       .map((r) => ({
         id: r.id,
         user_id: r.user_id,
+        parent_reply_id: r.parent_reply_id,
         body: r.body,
         created_at: r.created_at,
         updated_at: r.updated_at,

--- a/src/lib/queries/posts.ts
+++ b/src/lib/queries/posts.ts
@@ -23,8 +23,10 @@ export type MentionedUserMini = Pick<
 //           mentioned_user is the recommendation target.
 export type FeedReply = {
   id: number
+  user_id: string | null
   body: string
   created_at: string
+  updated_at: string | null
   is_ai: boolean
   author: ReplyAuthorMini | null
   mentioned_user: MentionedUserMini | null
@@ -57,7 +59,7 @@ export async function fetchFeed(
        match_intent, created_at,
        author:users!user_id ( nickname, company, contact_handle, is_vip, vip_name, vip_title ),
        replies (
-         id, body, created_at, is_ai, visibility, mentioned_user_id,
+         id, user_id, body, created_at, updated_at, is_ai, visibility, mentioned_user_id,
          author:users!user_id ( nickname, company, is_vip, vip_name, vip_title ),
          mentioned_user:users!mentioned_user_id ( id, nickname, is_vip, vip_name )
        )`,
@@ -115,8 +117,10 @@ export async function fetchFeed(
     const author = unnestRelation(row.author) as AuthorMini
     const repliesRaw = (row.replies ?? []) as Array<{
       id: number
+      user_id: string | null
       body: string
       created_at: string
+      updated_at: string | null
       is_ai: boolean
       visibility: 'public' | 'author_only'
       mentioned_user_id: string | null
@@ -129,8 +133,10 @@ export async function fetchFeed(
       .filter((r) => r.visibility === 'public' || isPostAuthor)
       .map((r) => ({
         id: r.id,
+        user_id: r.user_id,
         body: r.body,
         created_at: r.created_at,
+        updated_at: r.updated_at,
         is_ai: r.is_ai,
         author: r.author ? (unnestRelation(r.author) as ReplyAuthorMini) : null,
         mentioned_user: r.mentioned_user

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,7 @@ export type ReplyRow = {
   id: number
   post_id: number
   user_id: string | null
+  parent_reply_id: number | null
   body: string
   created_at: string
   updated_at: string | null

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,7 @@ export type ReplyRow = {
   user_id: string | null
   body: string
   created_at: string
+  updated_at: string | null
   is_ai: boolean
   visibility: ReplyVisibility
   mentioned_user_id: string | null

--- a/supabase/migrations/0006_reply_edits.sql
+++ b/supabase/migrations/0006_reply_edits.sql
@@ -1,0 +1,8 @@
+-- =====================================================================
+-- 0006_reply_edits.sql — let users edit / delete their own replies
+-- =====================================================================
+-- updated_at is NULL until the first edit. The UI shows "已编辑" iff
+-- updated_at is not null. Server actions (updateReplyAction) explicitly
+-- set updated_at = now() on edit; no trigger.
+
+alter table replies add column updated_at timestamptz;

--- a/supabase/migrations/0007_reply_threads.sql
+++ b/supabase/migrations/0007_reply_threads.sql
@@ -1,0 +1,22 @@
+-- =====================================================================
+-- 0007_reply_threads.sql — one-level nested replies
+-- =====================================================================
+-- parent_reply_id = NULL  → top-level reply
+-- parent_reply_id != NULL → child of that reply
+--
+-- We allow only one nesting level: createReplyAction flattens any reply
+-- whose parent itself has a parent (i.e. replying to a child of the
+-- top-level) up to the top-level. Schema does NOT enforce this — the
+-- check sits in the server action so we can change UX later without
+-- migrating data.
+--
+-- ON DELETE CASCADE: if a top-level reply is deleted, its children go
+-- with it. Acceptable for an event-scoped app — keeping orphaned
+-- "@张三 ..." replies pointing at nothing is more confusing.
+
+alter table replies
+  add column parent_reply_id bigint references replies(id) on delete cascade;
+
+create index replies_parent_reply_id_idx
+  on replies (parent_reply_id)
+  where parent_reply_id is not null;


### PR DESCRIPTION
3 个独立 commit，可分开审查。

## Summary

| Commit | 改动 |
|---|---|
| `feat: 嘉宾自填昵称/公司覆盖默认显示` | 抽 `displayName/displayMeta` helper 单点；VIP 自填 `nickname` / `company` 优先于预设 `vip_name` / `vip_title`；留空 fallback 到预设 |
| `feat: 用户可编辑/删除自己的回复` | migration **0006** 加 `replies.updated_at`；`updateReplyAction` / `deleteReplyAction` 用 `.eq('user_id', user.id)` 鉴权；ReplyRow 仅作者本人显示 编辑/删除 按钮；显示"已编辑"标 |
| `feat: 回复嵌套（一层）` | migration **0007** 加 `replies.parent_reply_id` (ON DELETE CASCADE)；`createReplyAction` 扁平逻辑（父本身有父则用爷爷的 id，永远只有一层 child）；ReplySection 两层树渲染 + "正在回复 @<name> ✕" 提示 |

## 关键设计决策

- **嘉宾覆盖规则**：`nickname ?? (is_vip ? vip_name ?? '嘉宾' : '匿名')`，公司同理。让 VIP 有自由调整显示文案的空间，又不丢失主办方预设的 fallback。
- **回复编辑/删除鉴权**：靠 `.eq('user_id', user.id)` 让 SQL 层过滤；非 owner 受影响 0 行，AI reply (`user_id IS NULL`) 自然排除。不需要单独 if 检查。
- **嵌套深度只一层**：reply 子节点不再有子节点。Server 端 `createReplyAction` 检查父的父，自动扁平到 top-level；client 渲染只组织两层树。Reddit 风格的无限嵌套对 100 字短消息和移动端都不合适。
- **保留 @mention 文字**：嵌套渲染已经表达回复关系，但 `@<name>` 文字保留，方便没展开 thread 的人也能看出在跟谁说话。

## ⚠️ 部署前必做：手工应用 migrations 0006 + 0007

不应用会让 fetchFeed select 不存在的列，整个 feed 挂。

```sql
-- 0006
alter table replies add column updated_at timestamptz;

-- 0007
alter table replies
  add column parent_reply_id bigint references replies(id) on delete cascade;
create index replies_parent_reply_id_idx
  on replies (parent_reply_id) where parent_reply_id is not null;
```

或直接跑 `supabase/migrations/0006_reply_edits.sql` 和 `supabase/migrations/0007_reply_threads.sql`。

## Test plan

- [x] `tsc --noEmit` 通过
- [x] `eslint src` 通过
- [x] `vitest` 9/9 通过
- [x] 本地 dev 验过（用户确认）：嘉宾覆盖、回复编辑/删除、嵌套渲染、扁平规则、@mention 提示
- [ ] migration 0006 + 0007 应用到 Supabase（部署前）
- [ ] CF auto-deploy 后 production 验

🤖 Generated with [Claude Code](https://claude.com/claude-code)