### PR TITLE
feat: 用户可编辑/删除自己的帖子

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,5 +1,10 @@
+'use client'
+
+import { useState, useTransition } from 'react'
 import type { FeedPost } from '@/lib/queries/posts'
 import { displayName, displayMeta } from '@/lib/display'
+import { POST_MAX_CHARS } from '@/lib/constants'
+import { deletePostAction, updatePostAction } from '@/lib/actions/posts'
 import { LikeButton } from './LikeButton'
 import { PollCard } from './PollCard'
 import { ReplySection } from './ReplySection'
@@ -11,6 +16,51 @@ export function PostCard({ post, viewerId }: Props) {
   const name = displayName(author)
   const meta = displayMeta(author)
   const isPoll = post.type === 'poll'
+  const isMine = post.user_id === viewerId
+
+  const [editing, setEditing] = useState(false)
+  const [body, setBody] = useState(post.body)
+  const [tags, setTags] = useState(post.tags.join(' '))
+  const [error, setError] = useState<string | null>(null)
+  const [pending, startTransition] = useTransition()
+
+  const remaining = POST_MAX_CHARS - body.length
+
+  function onSaveEdit() {
+    const trimmed = body.trim()
+    if (!trimmed) {
+      setError('内容不能为空')
+      return
+    }
+    if (trimmed.length > POST_MAX_CHARS) {
+      setError(`不能超过 ${POST_MAX_CHARS} 字`)
+      return
+    }
+    startTransition(async () => {
+      const res = await updatePostAction(post.id, trimmed, tags)
+      if (res.error) {
+        setError(res.error)
+      } else {
+        setError(null)
+        setEditing(false)
+      }
+    })
+  }
+
+  function onCancelEdit() {
+    setEditing(false)
+    setError(null)
+    setBody(post.body)
+    setTags(post.tags.join(' '))
+  }
+
+  function onDelete() {
+    if (!window.confirm(isPoll ? '删除这条投票？所有投票数据会一起清掉。' : '删除这条帖子？回复也会一起删掉。')) return
+    startTransition(async () => {
+      const res = await deletePostAction(post.id)
+      if (res.error) setError(res.error)
+    })
+  }
 
   return (
     <article id={`post-${post.id}`} className="scroll-mt-20 rounded-xl border border-zinc-200 bg-white p-4 shadow-sm">
@@ -28,11 +78,76 @@ export function PostCard({ post, viewerId }: Props) {
           </span>
         )}
         <span className="ml-auto text-xs text-zinc-400">{formatTime(post.created_at)}</span>
+        {isMine && !editing && (
+          <div className="flex items-center gap-1">
+            {!isPoll && (
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                className="rounded px-1.5 py-0.5 text-xs text-zinc-500 hover:bg-zinc-100 hover:text-zinc-800"
+              >
+                编辑
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onDelete}
+              disabled={pending}
+              className="rounded px-1.5 py-0.5 text-xs text-red-500 hover:bg-red-50 hover:text-red-700 disabled:opacity-50"
+            >
+              删除
+            </button>
+          </div>
+        )}
       </header>
 
-      <p className="whitespace-pre-wrap text-[15px] leading-relaxed text-zinc-800">
-        {post.body}
-      </p>
+      {editing ? (
+        <div className="space-y-2">
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            maxLength={POST_MAX_CHARS}
+            rows={4}
+            className="w-full resize-none rounded-md border border-zinc-200 bg-white px-3 py-2 text-[15px] focus:border-zinc-400 focus:outline-none"
+          />
+          <input
+            type="text"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            placeholder="标签（空格分隔，最多 5 个）"
+            className="w-full rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-sm placeholder:text-zinc-400 focus:border-zinc-400 focus:outline-none"
+          />
+          <div className="flex items-center justify-between text-xs text-zinc-400">
+            <span className={remaining < 0 ? 'text-red-500' : ''}>
+              {remaining < 0 ? remaining : ''}
+            </span>
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={onCancelEdit}
+                disabled={pending}
+                className="rounded-md px-2.5 py-1 text-xs text-zinc-500 hover:bg-zinc-100 disabled:opacity-50"
+              >
+                取消
+              </button>
+              <button
+                type="button"
+                onClick={onSaveEdit}
+                disabled={pending || body.trim().length === 0 || remaining < 0}
+                className="rounded-md bg-zinc-900 px-3 py-1 text-xs font-medium text-white hover:bg-zinc-800 disabled:bg-zinc-300"
+              >
+                {pending ? '保存中…' : '保存'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <p className="whitespace-pre-wrap text-[15px] leading-relaxed text-zinc-800">
+          {post.body}
+        </p>
+      )}
+
+      {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
 
       {isPoll && post.poll_options && (
         <PollCard
@@ -47,7 +162,7 @@ export function PostCard({ post, viewerId }: Props) {
         />
       )}
 
-      {!isPoll && post.tags.length > 0 && (
+      {!isPoll && !editing && post.tags.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1.5">
           {post.tags.map((tag) => (
             <span

--- a/src/lib/actions/posts.ts
+++ b/src/lib/actions/posts.ts
@@ -8,6 +8,7 @@ import { POST_MAX_CHARS, MATCH_INTENT_MAX_CHARS } from '@/lib/constants'
 import { isSectionId } from '@/lib/sections'
 
 export type PostFormState = { error: string | null; ok?: boolean }
+export type PostMutationResult = { error: string | null }
 
 export async function createPostAction(
   _prev: PostFormState,
@@ -78,4 +79,60 @@ function parseTags(raw: string): string[] {
         .filter(Boolean),
     ),
   ).slice(0, 5)
+}
+
+// Authorize-by-filter: .eq('user_id', user.id) means a non-owner update
+// hits 0 rows. Polls can be deleted but not edited (vote integrity).
+export async function updatePostAction(
+  postId: number,
+  body: string,
+  tagsRaw: string,
+): Promise<PostMutationResult> {
+  const user = await getCurrentUser()
+  if (!user) redirect('/')
+
+  if (!Number.isInteger(postId) || postId <= 0) return { error: '帖子 id 不对' }
+  const trimmed = String(body ?? '').trim()
+  if (!trimmed) return { error: '内容不能为空' }
+  if (trimmed.length > POST_MAX_CHARS) return { error: `不能超过 ${POST_MAX_CHARS} 字` }
+
+  const sb = getServerSupabase()
+  const { data, error } = await sb
+    .from('posts')
+    .update({ body: trimmed, tags: parseTags(String(tagsRaw ?? '')) })
+    .eq('id', postId)
+    .eq('user_id', user.id)
+    .eq('type', 'text')
+    .select('id')
+    .maybeSingle()
+
+  if (error) return { error: error.message }
+  if (!data) return { error: '没找到这条帖子，或者它不是你的（投票贴不可编辑）' }
+
+  revalidatePath('/feed')
+  revalidatePath('/me')
+  return { error: null }
+}
+
+export async function deletePostAction(postId: number): Promise<PostMutationResult> {
+  const user = await getCurrentUser()
+  if (!user) redirect('/')
+
+  if (!Number.isInteger(postId) || postId <= 0) return { error: '帖子 id 不对' }
+
+  const sb = getServerSupabase()
+  const { data, error } = await sb
+    .from('posts')
+    .delete()
+    .eq('id', postId)
+    .eq('user_id', user.id)
+    .select('id')
+    .maybeSingle()
+
+  if (error) return { error: error.message }
+  if (!data) return { error: '没找到这条帖子，或者它不是你的' }
+
+  revalidatePath('/feed')
+  revalidatePath('/me')
+  return { error: null }
 }


### PR DESCRIPTION
## Summary
- 自己的帖子右上角显示「编辑」「删除」按钮，别人的帖子不显示
- 文本贴可改 body 和 tags；投票贴只允许删除（保护投票数据完整性）
- 删除依赖 schema 已有的 `ON DELETE CASCADE`，自动清理 replies / likes / poll_votes
- 鉴权走 `.eq('user_id', user.id)` 命中 0 行的方式，跟 reply 编辑/删除一致

## Test plan
- [ ] 自己的文本贴显示「编辑」「删除」，别人的帖子不显示按钮
- [ ] 自己的投票贴只显示「删除」，无「编辑」
- [ ] 编辑保存后 body 和 tags 都更新
- [ ] 删除后帖子从 timeline 消失，回复/赞一并清空
- [ ] 别人不能通过手动调 server action 改/删我的帖子（authorize-by-filter 兜底）

🤖 Generated with [Claude Code](https://claude.com/claude-code)