### PR TITLE
test: 加 display / sections / tags 的 unit test

### DIFF
--- a/src/lib/actions/posts.ts
+++ b/src/lib/actions/posts.ts
@@ -6,6 +6,7 @@ import { getCurrentUser } from '@/lib/identity'
 import { getServerSupabase } from '@/lib/supabase/server'
 import { POST_MAX_CHARS, MATCH_INTENT_MAX_CHARS } from '@/lib/constants'
 import { isSectionId } from '@/lib/sections'
+import { parseTags } from '@/lib/tags'
 
 export type PostFormState = { error: string | null; ok?: boolean }
 export type PostMutationResult = { error: string | null }
@@ -68,17 +69,6 @@ function nullableStr(v: FormDataEntryValue | null): string | null | undefined {
   if (v == null) return undefined
   const s = String(v).trim()
   return s.length === 0 ? null : s
-}
-
-function parseTags(raw: string): string[] {
-  return Array.from(
-    new Set(
-      raw
-        .split(/[\s,，；;]+/)
-        .map((t) => t.replace(/^#/, '').trim().toLowerCase())
-        .filter(Boolean),
-    ),
-  ).slice(0, 5)
 }
 
 // Authorize-by-filter: .eq('user_id', user.id) means a non-owner update

--- a/src/lib/display.test.ts
+++ b/src/lib/display.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { displayName, displayMeta, type DisplayUser } from './display'
+
+const base: DisplayUser = {
+  nickname: null,
+  company: null,
+  is_vip: false,
+  vip_name: null,
+  vip_title: null,
+}
+
+describe('displayName', () => {
+  it('uses self-edited nickname when present', () => {
+    expect(displayName({ ...base, nickname: '小明' })).toBe('小明')
+  })
+
+  it('VIP without nickname falls back to vip_name', () => {
+    expect(displayName({ ...base, is_vip: true, vip_name: '张教授' })).toBe('张教授')
+  })
+
+  it('VIP nickname overrides vip_name', () => {
+    expect(
+      displayName({ ...base, is_vip: true, nickname: '老张', vip_name: '张教授' }),
+    ).toBe('老张')
+  })
+
+  it('VIP without nickname or vip_name falls back to 嘉宾', () => {
+    expect(displayName({ ...base, is_vip: true })).toBe('嘉宾')
+  })
+
+  it('non-VIP without nickname is 匿名', () => {
+    expect(displayName(base)).toBe('匿名')
+  })
+
+  it('empty-string nickname is treated as a real value (no coercion)', () => {
+    // 与代码契约一致：null 才走 fallback；空串由 server action 在写入前 trim 成 null
+    expect(displayName({ ...base, nickname: '' })).toBe('')
+  })
+})
+
+describe('displayMeta', () => {
+  it('uses self-edited company when present', () => {
+    expect(displayMeta({ ...base, company: 'Acme' })).toBe('Acme')
+  })
+
+  it('VIP without company falls back to vip_title', () => {
+    expect(displayMeta({ ...base, is_vip: true, vip_title: 'CTO' })).toBe('CTO')
+  })
+
+  it('VIP company overrides vip_title', () => {
+    expect(
+      displayMeta({ ...base, is_vip: true, company: 'NewCo', vip_title: 'CTO' }),
+    ).toBe('NewCo')
+  })
+
+  it('non-VIP without company returns null', () => {
+    expect(displayMeta(base)).toBeNull()
+  })
+
+  it('VIP without company or vip_title returns null', () => {
+    expect(displayMeta({ ...base, is_vip: true })).toBeNull()
+  })
+})

--- a/src/lib/sections.test.ts
+++ b/src/lib/sections.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { isSectionId, sectionLabel, SECTIONS, DEFAULT_SECTION } from './sections'
+
+describe('isSectionId', () => {
+  it.each(SECTIONS.map((s) => s.id))('accepts known id %s', (id) => {
+    expect(isSectionId(id)).toBe(true)
+  })
+
+  it('rejects unknown strings', () => {
+    expect(isSectionId('p3')).toBe(false)
+    expect(isSectionId('')).toBe(false)
+  })
+
+  it('rejects non-string values', () => {
+    expect(isSectionId(null)).toBe(false)
+    expect(isSectionId(undefined)).toBe(false)
+    expect(isSectionId(1)).toBe(false)
+    expect(isSectionId({})).toBe(false)
+  })
+})
+
+describe('sectionLabel', () => {
+  it.each(SECTIONS)('returns label for $id', ({ id, label }) => {
+    expect(sectionLabel(id)).toBe(label)
+  })
+
+  it('DEFAULT_SECTION is a valid id', () => {
+    expect(isSectionId(DEFAULT_SECTION)).toBe(true)
+    expect(sectionLabel(DEFAULT_SECTION)).toBeTruthy()
+  })
+})

--- a/src/lib/tags.test.ts
+++ b/src/lib/tags.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { parseTags, MAX_TAGS } from './tags'
+
+describe('parseTags', () => {
+  it('returns empty array for empty / whitespace input', () => {
+    expect(parseTags('')).toEqual([])
+    expect(parseTags('   ')).toEqual([])
+  })
+
+  it('splits on spaces, commas (EN+CN), semicolons (EN+CN)', () => {
+    expect(parseTags('ai ml,data，infra;cloud；devops')).toEqual([
+      'ai',
+      'ml',
+      'data',
+      'infra',
+      'cloud',
+    ])
+  })
+
+  it('strips leading # from each tag', () => {
+    expect(parseTags('#ai #ml #data')).toEqual(['ai', 'ml', 'data'])
+  })
+
+  it('lowercases tags', () => {
+    expect(parseTags('AI ML DataEng')).toEqual(['ai', 'ml', 'dataeng'])
+  })
+
+  it('dedupes case-insensitively', () => {
+    expect(parseTags('ai AI Ai #ai')).toEqual(['ai'])
+  })
+
+  it(`caps result at ${MAX_TAGS} tags`, () => {
+    const input = 'a b c d e f g h'
+    expect(parseTags(input)).toEqual(['a', 'b', 'c', 'd', 'e'])
+    expect(parseTags(input)).toHaveLength(MAX_TAGS)
+  })
+
+  it('handles mixed separators with extra whitespace', () => {
+    expect(parseTags('  ai , ,  ml  ;;  data  ')).toEqual(['ai', 'ml', 'data'])
+  })
+
+  it('preserves first-seen order after dedupe', () => {
+    expect(parseTags('ml ai ml ai data')).toEqual(['ml', 'ai', 'data'])
+  })
+})

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,16 @@
+// Free-form tag parsing for post composer input.
+// Splits on whitespace / comma (CN+EN) / semicolon, strips leading "#",
+// lowercases, dedupes, caps at 5.
+
+export const MAX_TAGS = 5
+
+export function parseTags(raw: string): string[] {
+  return Array.from(
+    new Set(
+      raw
+        .split(/[\s,，；;]+/)
+        .map((t) => t.replace(/^#/, '').trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  ).slice(0, MAX_TAGS)
+}


### PR DESCRIPTION
## Summary
- 补 `src/lib/` 纯函数的单测：`displayName` / `displayMeta`（VIP/fallback 分支）、`isSectionId` / `sectionLabel`、`parseTags`（多种分隔符 / `#` strip / 大小写 / 去重 / 限 5 个 / 顺序保持）
- 为了能测 `parseTags`，把它从 `src/lib/actions/posts.ts`（`'use server'` 文件只能 export async）抽到独立的 `src/lib/tags.ts`
- CI workflow 已存在（`.github/workflows/pr-checks.yml` 跑 typecheck + lint + test），无需修改

## Test plan
- [x] 本地 `npm run typecheck` 通过
- [x] 本地 `npm run lint` 通过
- [x] 本地 `npm test` 通过（5 文件 / 39 tests）
- [ ] CI PR checks 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)