### PR TITLE
feat: AI 撮合 — Edge Function + DeepSeek + pg_cron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ next-env.d.ts
 
 # local backups
 *.zip
+
+# supabase CLI scratch
+supabase/.temp/

--- a/scripts/deepseek-healthcheck.mjs
+++ b/scripts/deepseek-healthcheck.mjs
@@ -1,0 +1,68 @@
+// DeepSeek API 健康检查 — slice 3 实施前的连通性验证。
+//
+// 跑法：
+//   DEEPSEEK_API_KEY=$(secret get deepseek-dams-key) node scripts/deepseek-healthcheck.mjs
+//
+// 退出码：0 = 连通且能解析；非 0 = 配置 / 网络 / 解析异常。
+
+const apiKey = process.env.DEEPSEEK_API_KEY
+if (!apiKey) {
+  console.error('❌ DEEPSEEK_API_KEY 未设置')
+  console.error('   跑法：DEEPSEEK_API_KEY=$(secret get deepseek-dams-key) node scripts/deepseek-healthcheck.mjs')
+  process.exit(1)
+}
+
+const url = 'https://api.deepseek.com/chat/completions'
+const payload = {
+  model: 'deepseek-chat',
+  messages: [
+    { role: 'system', content: '只回复"ok"两个字，不要别的。' },
+    { role: 'user', content: 'ping' },
+  ],
+  max_tokens: 5,
+  temperature: 0,
+}
+
+const start = performance.now()
+let res
+try {
+  res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(payload),
+  })
+} catch (err) {
+  console.error('❌ 网络错误:', err.message)
+  process.exit(2)
+}
+const elapsed = Math.round(performance.now() - start)
+
+if (!res.ok) {
+  const text = await res.text().catch(() => '<empty>')
+  console.error(`❌ HTTP ${res.status} (${elapsed}ms)`)
+  console.error(`   body: ${text.slice(0, 500)}`)
+  process.exit(3)
+}
+
+let data
+try {
+  data = await res.json()
+} catch {
+  console.error(`❌ 解析 JSON 失败 (${elapsed}ms)`)
+  process.exit(4)
+}
+
+const reply = data?.choices?.[0]?.message?.content
+if (typeof reply !== 'string') {
+  console.error(`❌ 响应结构异常: 缺 choices[0].message.content`)
+  console.error('   raw:', JSON.stringify(data).slice(0, 500))
+  process.exit(5)
+}
+
+console.log(`✅ DeepSeek 连通 (${elapsed}ms)`)
+console.log(`   model: ${data.model}`)
+console.log(`   reply: ${reply.trim()}`)
+console.log(`   usage:`, data.usage)

--- a/supabase/functions/match/deepseek.ts
+++ b/supabase/functions/match/deepseek.ts
@@ -1,0 +1,81 @@
+// DeepSeek 客户端：发 chat completion，要求 JSON 输出，做严格解析。
+// 失败抛 Error，调用方负责 try/catch + 写 match_runs 日志。
+
+export type Recommendation = {
+  post_id: number
+  user_id: string
+  reason: string
+}
+
+const ENDPOINT = 'https://api.deepseek.com/chat/completions'
+
+const SYSTEM_PROMPT = `你是 DAMS Meetup 的 AI 撮合助手。会议主题：数据 / AI / 工程。
+
+每个 candidate 帖子是某用户**私下委托你**帮他匹配的需求（不公开，不要在 reason 中复述暗需求原文）。
+从全场用户画像中找最匹配的 1-3 人，给出**引用对方公开帖**的具体理由。
+
+严格输出 JSON：
+{
+  "recommendations": [
+    {"post_id": <number>, "user_id": "<uuid>", "reason": "<中文一句话>"}
+  ]
+}
+
+硬性要求：
+- 不要推荐 candidate 帖子的作者本人
+- post_id 必须来自 candidate 列表，user_id 必须来自全场画像
+- 每个 candidate 最多 3 条推荐；没合适的就少推荐或不推荐（不要硬凑）
+- reason 必须引用对方画像里的具体内容（公司 / 帖子 / tags），不要泛泛而谈
+- reason 不要复述 candidate 的暗需求原文，只说"你提到的需求"
+- 只输出 JSON，不要任何额外文字、不要 markdown 包裹`
+
+export async function callDeepSeek(userPrompt: string, apiKey: string): Promise<Recommendation[]> {
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'deepseek-chat',
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: userPrompt },
+      ],
+      response_format: { type: 'json_object' },
+      temperature: 0.3,
+    }),
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`DeepSeek HTTP ${res.status}: ${text.slice(0, 300)}`)
+  }
+
+  const data = await res.json()
+  const content = data?.choices?.[0]?.message?.content
+  if (typeof content !== 'string') {
+    throw new Error('DeepSeek response missing choices[0].message.content')
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch {
+    throw new Error(`DeepSeek output is not valid JSON: ${content.slice(0, 200)}`)
+  }
+
+  const recs = (parsed as { recommendations?: unknown })?.recommendations
+  if (!Array.isArray(recs)) {
+    throw new Error('DeepSeek output missing "recommendations" array')
+  }
+
+  return recs.filter((r: unknown): r is Recommendation =>
+    typeof r === 'object' &&
+    r !== null &&
+    typeof (r as Recommendation).post_id === 'number' &&
+    typeof (r as Recommendation).user_id === 'string' &&
+    typeof (r as Recommendation).reason === 'string' &&
+    (r as Recommendation).reason.length > 0,
+  )
+}

--- a/supabase/functions/match/index.ts
+++ b/supabase/functions/match/index.ts
@@ -1,0 +1,163 @@
+// AI 撮合 Edge Function — 拉候选 → 调 DeepSeek → 写 replies → 记 match_runs 日志。
+//
+// 触发：
+//   - cron（默认）：未处理的 match_intent 帖子 < MIN_INTENT_THRESHOLD 直接 skip
+//   - admin：URL ?force=<ADMIN_TOKEN> 跳过阈值
+//
+// env：SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY / DEEPSEEK_API_KEY / ADMIN_TOKEN
+
+import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { aggregateProfiles, buildPrompt, type CandidatePost, type RawPostWithUser } from './prompt.ts'
+import { callDeepSeek } from './deepseek.ts'
+
+const MIN_INTENT_THRESHOLD = 3
+const CANDIDATE_LIMIT = 50
+const PROFILES_POST_LIMIT = 500
+const REASON_MAX_CHARS = 500
+
+Deno.serve(async (req) => {
+  const url = new URL(req.url)
+  const forceToken = url.searchParams.get('force')
+  const adminToken = Deno.env.get('ADMIN_TOKEN')
+  const isAdmin = !!(adminToken && forceToken && forceToken === adminToken)
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+  const apiKey = Deno.env.get('DEEPSEEK_API_KEY')
+  if (!supabaseUrl || !serviceKey || !apiKey) {
+    return jsonResponse({ error: 'env not configured' }, 500)
+  }
+
+  const supabase = createClient(supabaseUrl, serviceKey)
+  const trigger = isAdmin ? 'admin' : 'cron'
+
+  const { data: run, error: runErr } = await supabase
+    .from('match_runs')
+    .insert({ status: 'running', trigger })
+    .select('id')
+    .single()
+  if (runErr || !run) {
+    return jsonResponse({ error: `run insert failed: ${runErr?.message}` }, 500)
+  }
+  const runId = run.id as number
+
+  try {
+    const candidates = await fetchCandidates(supabase)
+
+    if (!isAdmin && candidates.length < MIN_INTENT_THRESHOLD) {
+      await finishRun(supabase, runId, {
+        status: 'skipped_low_intent',
+        posts_processed: candidates.length,
+      })
+      return jsonResponse({ status: 'skipped_low_intent', candidates: candidates.length })
+    }
+
+    if (candidates.length === 0) {
+      await finishRun(supabase, runId, { status: 'success', posts_processed: 0 })
+      return jsonResponse({ status: 'success', candidates: 0 })
+    }
+
+    const profiles = await fetchProfiles(supabase)
+
+    const userPrompt = buildPrompt({ candidates, profiles })
+    const recs = await callDeepSeek(userPrompt, apiKey)
+
+    const candidateIds = new Set(candidates.map((c) => c.id))
+    const candidateAuthors = new Map(candidates.map((c) => [c.id, c.user_id]))
+
+    let inserted = 0
+    for (const rec of recs) {
+      if (!candidateIds.has(rec.post_id)) continue
+      if (candidateAuthors.get(rec.post_id) === rec.user_id) continue
+
+      const { error } = await supabase.from('replies').insert({
+        post_id: rec.post_id,
+        user_id: null,
+        is_ai: true,
+        visibility: 'author_only',
+        body: rec.reason.slice(0, REASON_MAX_CHARS),
+        mentioned_user_id: rec.user_id,
+      })
+      if (!error) {
+        inserted++
+      } else if (error.code !== '23505') {
+        // 23505 = unique violation = dedup index 命中，静默跳过
+        console.error(`insert failed post=${rec.post_id} user=${rec.user_id}: ${error.message}`)
+      }
+    }
+
+    await finishRun(supabase, runId, {
+      status: 'success',
+      posts_processed: candidates.length,
+      replies_inserted: inserted,
+    })
+
+    return jsonResponse({
+      status: 'success',
+      candidates: candidates.length,
+      recommendations: recs.length,
+      inserted,
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    await finishRun(supabase, runId, { status: 'failed', error: msg.slice(0, 1000) })
+    return jsonResponse({ status: 'failed', error: msg }, 500)
+  }
+})
+
+async function fetchCandidates(supabase: SupabaseClient): Promise<CandidatePost[]> {
+  const { data: all, error } = await supabase
+    .from('posts')
+    .select('id, content, tags, section, user_id, match_intent, created_at')
+    .not('match_intent', 'is', null)
+    .order('created_at', { ascending: false })
+    .limit(CANDIDATE_LIMIT)
+  if (error) throw new Error(`candidate query: ${error.message}`)
+
+  // 排除已经有 AI reply 的帖子（避免重复处理）
+  const { data: processed, error: procErr } = await supabase
+    .from('replies')
+    .select('post_id')
+    .eq('is_ai', true)
+  if (procErr) throw new Error(`processed query: ${procErr.message}`)
+  const skip = new Set((processed ?? []).map((r) => r.post_id))
+
+  return (all ?? [])
+    .filter((p) => !skip.has(p.id) && typeof p.match_intent === 'string')
+    .map((p) => ({
+      id: p.id,
+      content: p.content,
+      tags: p.tags,
+      section: p.section,
+      user_id: p.user_id,
+      match_intent: p.match_intent,
+    }))
+}
+
+async function fetchProfiles(supabase: SupabaseClient) {
+  const { data, error } = await supabase
+    .from('posts')
+    .select('user_id, content, tags, section, users:user_id (id, nickname, company, is_vip, vip_name, vip_title)')
+    .order('created_at', { ascending: false })
+    .limit(PROFILES_POST_LIMIT)
+  if (error) throw new Error(`profiles query: ${error.message}`)
+  return aggregateProfiles((data ?? []) as unknown as RawPostWithUser[])
+}
+
+async function finishRun(
+  supabase: SupabaseClient,
+  runId: number,
+  fields: Record<string, unknown>,
+) {
+  await supabase
+    .from('match_runs')
+    .update({ ...fields, finished_at: new Date().toISOString() })
+    .eq('id', runId)
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/supabase/functions/match/index.ts
+++ b/supabase/functions/match/index.ts
@@ -108,7 +108,7 @@ Deno.serve(async (req) => {
 async function fetchCandidates(supabase: SupabaseClient): Promise<CandidatePost[]> {
   const { data: all, error } = await supabase
     .from('posts')
-    .select('id, content, tags, section, user_id, match_intent, created_at')
+    .select('id, body, tags, section, user_id, match_intent, created_at')
     .not('match_intent', 'is', null)
     .order('created_at', { ascending: false })
     .limit(CANDIDATE_LIMIT)
@@ -126,7 +126,7 @@ async function fetchCandidates(supabase: SupabaseClient): Promise<CandidatePost[
     .filter((p) => !skip.has(p.id) && typeof p.match_intent === 'string')
     .map((p) => ({
       id: p.id,
-      content: p.content,
+      body: p.body,
       tags: p.tags,
       section: p.section,
       user_id: p.user_id,
@@ -137,7 +137,7 @@ async function fetchCandidates(supabase: SupabaseClient): Promise<CandidatePost[
 async function fetchProfiles(supabase: SupabaseClient) {
   const { data, error } = await supabase
     .from('posts')
-    .select('user_id, content, tags, section, users:user_id (id, nickname, company, is_vip, vip_name, vip_title)')
+    .select('user_id, body, tags, section, users:user_id (id, nickname, company, is_vip, vip_name, vip_title)')
     .order('created_at', { ascending: false })
     .limit(PROFILES_POST_LIMIT)
   if (error) throw new Error(`profiles query: ${error.message}`)

--- a/supabase/functions/match/prompt.ts
+++ b/supabase/functions/match/prompt.ts
@@ -3,7 +3,7 @@
 
 export type CandidatePost = {
   id: number
-  content: string
+  body: string
   tags: string[] | null
   section: string | null
   user_id: string
@@ -14,7 +14,7 @@ export type UserProfile = {
   user_id: string
   display_name: string
   affiliation: string | null
-  posts: Array<{ content: string; tags: string[] | null; section: string | null }>
+  posts: Array<{ body: string; tags: string[] | null; section: string | null }>
 }
 
 const SECTION_LABEL: Record<string, string> = {
@@ -39,7 +39,7 @@ export function buildPrompt(args: {
   for (const c of args.candidates) {
     lines.push(`### post_id=${c.id}`)
     lines.push(`作者 user_id=${c.user_id} | 板块: ${labelSection(c.section)}`)
-    lines.push(`公开内容: ${c.content}`)
+    lines.push(`公开内容: ${c.body}`)
     if (c.tags?.length) lines.push(`tags: ${c.tags.join(', ')}`)
     lines.push(`暗需求: ${c.match_intent}`)
     lines.push('')
@@ -52,7 +52,7 @@ export function buildPrompt(args: {
     lines.push(`### user_id=${p.user_id} | ${head}`)
     for (const post of p.posts.slice(0, 5)) {
       const tags = post.tags?.length ? ` [${post.tags.join(',')}]` : ''
-      const snippet = post.content.length > 120 ? post.content.slice(0, 120) + '…' : post.content
+      const snippet = post.body.length > 120 ? post.body.slice(0, 120) + '…' : post.body
       lines.push(`- [${labelSection(post.section)}]${tags} ${snippet}`)
     }
     lines.push('')
@@ -63,7 +63,7 @@ export function buildPrompt(args: {
 
 export type RawPostWithUser = {
   user_id: string | null
-  content: string
+  body: string
   tags: string[] | null
   section: string | null
   users: {
@@ -94,7 +94,7 @@ export function aggregateProfiles(rows: RawPostWithUser[]): UserProfile[] {
       map.set(row.user_id, profile)
     }
     profile.posts.push({
-      content: row.content,
+      body: row.body,
       tags: row.tags,
       section: row.section,
     })

--- a/supabase/functions/match/prompt.ts
+++ b/supabase/functions/match/prompt.ts
@@ -1,0 +1,103 @@
+// 纯函数：把候选帖子 + 全场画像组装成 LLM 输入。
+// 抽出来便于本地单测（不依赖 Deno / Supabase 环境）。
+
+export type CandidatePost = {
+  id: number
+  content: string
+  tags: string[] | null
+  section: string | null
+  user_id: string
+  match_intent: string
+}
+
+export type UserProfile = {
+  user_id: string
+  display_name: string
+  affiliation: string | null
+  posts: Array<{ content: string; tags: string[] | null; section: string | null }>
+}
+
+const SECTION_LABEL: Record<string, string> = {
+  p1: 'Presentation 1',
+  p2: 'Presentation 2',
+  breakout: 'Breakout',
+  panel: 'Panel',
+}
+
+function labelSection(s: string | null): string {
+  return s ? SECTION_LABEL[s] ?? s : 'Pre-event'
+}
+
+export function buildPrompt(args: {
+  candidates: CandidatePost[]
+  profiles: UserProfile[]
+}): string {
+  const lines: string[] = []
+
+  lines.push('## 需要匹配的 candidate 帖子（含暗需求，仅你可见）')
+  lines.push('')
+  for (const c of args.candidates) {
+    lines.push(`### post_id=${c.id}`)
+    lines.push(`作者 user_id=${c.user_id} | 板块: ${labelSection(c.section)}`)
+    lines.push(`公开内容: ${c.content}`)
+    if (c.tags?.length) lines.push(`tags: ${c.tags.join(', ')}`)
+    lines.push(`暗需求: ${c.match_intent}`)
+    lines.push('')
+  }
+
+  lines.push('## 全场用户画像（按公开帖聚合）')
+  lines.push('')
+  for (const p of args.profiles) {
+    const head = p.affiliation ? `${p.display_name} · ${p.affiliation}` : p.display_name
+    lines.push(`### user_id=${p.user_id} | ${head}`)
+    for (const post of p.posts.slice(0, 5)) {
+      const tags = post.tags?.length ? ` [${post.tags.join(',')}]` : ''
+      const snippet = post.content.length > 120 ? post.content.slice(0, 120) + '…' : post.content
+      lines.push(`- [${labelSection(post.section)}]${tags} ${snippet}`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+export type RawPostWithUser = {
+  user_id: string | null
+  content: string
+  tags: string[] | null
+  section: string | null
+  users: {
+    id: string
+    nickname: string | null
+    company: string | null
+    is_vip: boolean
+    vip_name: string | null
+    vip_title: string | null
+  } | null
+}
+
+export function aggregateProfiles(rows: RawPostWithUser[]): UserProfile[] {
+  const map = new Map<string, UserProfile>()
+  for (const row of rows) {
+    if (!row.user_id || !row.users) continue
+    let profile = map.get(row.user_id)
+    if (!profile) {
+      const u = row.users
+      const display = u.is_vip ? u.vip_name ?? '嘉宾' : u.nickname ?? '匿名'
+      const aff = u.is_vip ? u.vip_title : u.company
+      profile = {
+        user_id: row.user_id,
+        display_name: display,
+        affiliation: aff,
+        posts: [],
+      }
+      map.set(row.user_id, profile)
+    }
+    profile.posts.push({
+      content: row.content,
+      tags: row.tags,
+      section: row.section,
+    })
+  }
+  return Array.from(map.values())
+}

--- a/supabase/migrations/0008_match_runs.sql
+++ b/supabase/migrations/0008_match_runs.sql
@@ -1,0 +1,29 @@
+-- F'' AI 撮合 slice 3 — 日志表 + AI reply dedup 唯一约束。
+-- 见 docs/matching-design.md §3 方案 F''、§6 实现 checklist。
+
+-- 1. match_runs — 每次撮合一条记录，用于诊断 + 决定下一次是否跳过低 intent
+create table match_runs (
+  id bigserial primary key,
+  started_at timestamptz not null default now(),
+  finished_at timestamptz,
+  status text not null
+    check (status in ('running', 'success', 'skipped_low_intent', 'failed')),
+  trigger text not null
+    check (trigger in ('cron', 'admin')),
+  posts_processed int not null default 0,
+  replies_inserted int not null default 0,
+  error text
+);
+
+create index match_runs_started_idx on match_runs (started_at desc);
+
+-- 默认无 RLS policy = anon 读不到；service_role 不受 RLS 影响。
+-- 这张表只用于运维，不暴露给客户端。
+alter table match_runs enable row level security;
+
+-- 2. dedup: 同一 (post_id, mentioned_user_id) 只允许一条 AI reply
+-- 让 INSERT ON CONFLICT DO NOTHING 在重复推荐时静默跳过。
+-- partial index 不影响普通 (is_ai=false) reply。
+create unique index replies_ai_dedup_idx
+  on replies (post_id, mentioned_user_id)
+  where is_ai = true and mentioned_user_id is not null;

--- a/supabase/migrations/0009_match_cron.sql
+++ b/supabase/migrations/0009_match_cron.sql
@@ -1,0 +1,47 @@
+-- F'' AI 撮合 slice 3 — pg_cron 30min 触发 Edge Function。
+-- 见 docs/matching-design.md §3 方案 F''。
+--
+-- 应用前置（人工，跑 migration 前必须先做）：
+--
+--   A. Supabase Dashboard → Database → Vault → New secret:
+--        name:  service_role_key
+--        value: <Project Settings → API → service_role>
+--
+--   B. (已替换好) Edge Function URL 用的是 project ref = eniydtuycfekkwirasto
+--
+-- 触发逻辑：
+--   - cron 30min 自动触发 → Edge Function 内部判断 < 3 条新 intent 就 skip
+--   - 强制触发：直接访问 https://<ref>.supabase.co/functions/v1/match?force=<ADMIN_TOKEN>
+--     (ADMIN_TOKEN 由 supabase secrets set ADMIN_TOKEN=... 配置)
+
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+-- 幂等：先取消同名旧 job（首次跑时不存在会抛错，吞掉）
+do $$
+begin
+  perform cron.unschedule('ai-matching-30min');
+exception when others then null;
+end $$;
+
+select cron.schedule(
+  'ai-matching-30min',
+  '*/30 * * * *',
+  $$
+  select net.http_post(
+    url := 'https://eniydtuycfekkwirasto.supabase.co/functions/v1/match',
+    headers := jsonb_build_object(
+      'Authorization',
+      'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'service_role_key'),
+      'Content-Type', 'application/json'
+    )
+  ) as request_id;
+  $$
+);
+
+-- 查询 cron 状态：
+--   select * from cron.job;
+--   select * from cron.job_run_details order by start_time desc limit 10;
+--
+-- 卸载：
+--   select cron.unschedule('ai-matching-30min');

--- a/supabase/seeds/mock-ai-reply.sql
+++ b/supabase/seeds/mock-ai-reply.sql
@@ -1,0 +1,70 @@
+-- F'' AI 撮合 slice 2 — 手工 mock 一条 AI reply，验证 UI 渲染链路。
+--
+-- 跑法：
+--   1. Supabase SQL Editor 全选粘贴执行
+--   2. NOTICE 输出 post_id / author_uid / mentioned_uid
+--   3. dev：用 author_uid 的浏览器打开 /feed → 该 post 下方应出现蓝色 "AI 撮合 · 仅你可见" 卡
+--   4. dev：用 mentioned_uid 的浏览器打开 /me → "有人想找你" section 应有一条
+--   5. 第三方浏览器（既不是 author 也不是 mentioned）打开 /feed → 看不到这条 AI reply
+--   6. 清理：脚本会在每次执行开头自动删除带 [slice2 mock] 标记的旧记录
+--
+-- 前置：posts 表至少 1 条带 author 的记录；users 表至少 2 个用户
+
+begin;
+
+-- 1. 清掉前一次的 mock（idempotent，反复跑不会堆积）
+delete from replies where is_ai = true and body like '%[slice2 mock]%';
+
+-- 2. 选最近一条有 author 的 post + 一个不同的 user，插入 mock AI reply
+do $$
+declare
+  v_post_id bigint;
+  v_author_uid uuid;
+  v_author_token text;
+  v_mentioned_uid uuid;
+  v_mentioned_token text;
+  v_reply_id bigint;
+begin
+  select p.id, p.user_id, u.recovery_token
+    into v_post_id, v_author_uid, v_author_token
+  from posts p
+  join users u on u.id = p.user_id
+  where p.user_id is not null
+  order by p.created_at desc
+  limit 1;
+
+  if v_post_id is null then
+    raise exception '需要先在 dev /feed 发一条帖子作为载体';
+  end if;
+
+  select id, recovery_token into v_mentioned_uid, v_mentioned_token
+  from users
+  where id <> v_author_uid
+  order by created_at desc nulls last
+  limit 1;
+
+  if v_mentioned_uid is null then
+    raise exception 'users 表只有 1 个用户 — 用 incognito 浏览器先访问一次 /feed 创建第二个 user';
+  end if;
+
+  insert into replies (post_id, user_id, is_ai, visibility, body, mentioned_user_id)
+  values (
+    v_post_id,
+    null,
+    true,
+    'author_only',
+    '[slice2 mock] 推荐你和这位用户聊聊 — 你私下提到的需求与对方画像匹配。',
+    v_mentioned_uid
+  )
+  returning id into v_reply_id;
+
+  raise notice '✅ mock AI reply created (reply_id=%, post_id=%)', v_reply_id, v_post_id;
+  raise notice ' ';
+  raise notice '验证（dev host = http://localhost:3000）：';
+  raise notice '  作者视角 → /feed 应见蓝色 AI 撮合卡：';
+  raise notice '    http://localhost:3000/recover?u=%&t=%', v_author_uid, v_author_token;
+  raise notice '  被提及视角 → /me "有人想找你" 应有一条：';
+  raise notice '    http://localhost:3000/recover?u=%&t=%', v_mentioned_uid, v_mentioned_token;
+end $$;
+
+commit;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase"]
 }


### PR DESCRIPTION
## Summary
- 完成 F'' AI 撮合 slice 2 + slice 3：从 slice 1 的 schema + 前端管道，扩展到 DeepSeek Edge Function + pg_cron 30min 自动触发 + admin token 强制触发
- 失败隔离：LLM 5xx / 网络 / JSON 解析失败写 `match_runs.status='failed'`，主 feed 不受影响
- Dedup：partial unique index `(post_id, mentioned_user_id) WHERE is_ai=true` 防止重复推荐

## Test plan
- [x] DeepSeek health check 通过（`scripts/deepseek-healthcheck.mjs`，628ms）
- [x] Migration 0008/0009 应用 + Supabase Vault `service_role_key` 配置
- [x] Edge Function 部署成功（61.84kB bundle）
- [x] admin trigger 端到端：候选 2 帖 → DeepSeek 2 推荐 → 2 reply 写入（4.1s）
- [x] 失败路径写 `match_runs.status='failed'`（首次部署因列名 bug 触发，已修复）
- [x] Slice 2 三视角 UI 验证：author 看到 AI 卡 / mentioned 看到 /me 提示 / 第三方看不到（visibility filter 工作）
- [ ] cron 自动触发（等下个整点 :00 或 :30 在 `cron.job_run_details` 观察）

## 已知 follow-up（不阻塞）
- Prompt engineering：当前数据稀疏时 LLM 会硬凑理由（"或许能接受辣味"），活动当天数据多大概率改善；如仍差，加强 system prompt 的"宁缺毋滥"约束
- 板块（section）信息已在 prompt 里作为上下文标注，未做硬过滤（跨板块匹配仍允许）

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)