### PR TITLE
feat: 站内信 (issue #6, scope C) + /me 接 Realtime

### DIFF
--- a/src/app/agenda/page.tsx
+++ b/src/app/agenda/page.tsx
@@ -1,7 +1,9 @@
 import { redirect } from 'next/navigation'
 import { getCurrentUser } from '@/lib/identity'
 import { Header } from '@/components/Header'
+import { DmRealtime } from '@/components/DmRealtime'
 import { Agenda } from '@/components/Agenda'
+import { fetchUnreadDmCount } from '@/lib/queries/dm'
 
 export const dynamic = 'force-dynamic'
 
@@ -9,9 +11,12 @@ export default async function AgendaPage() {
   const user = await getCurrentUser()
   if (!user) redirect('/')
 
+  const unreadDm = await fetchUnreadDmCount(user.id)
+
   return (
     <>
-      <Header active="agenda" />
+      <Header active="agenda" unreadDmCount={unreadDm} />
+      <DmRealtime viewerId={user.id} />
       <main className="mx-auto w-full max-w-2xl px-4 py-4">
         <Agenda />
       </main>

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -5,7 +5,10 @@ import { PostComposer } from '@/components/PostComposer'
 import { PostCard } from '@/components/PostCard'
 import { SectionTabs } from '@/components/SectionTabs'
 import { FeedRealtime } from '@/components/FeedRealtime'
+import { DmRealtime } from '@/components/DmRealtime'
 import { fetchFeed } from '@/lib/queries/posts'
+import { fetchUnreadDmCount } from '@/lib/queries/dm'
+import { isNonAnon } from '@/lib/dm'
 import { DEFAULT_SECTION, isSectionId } from '@/lib/sections'
 
 export const dynamic = 'force-dynamic'
@@ -26,12 +29,17 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
   // Fire-and-forget; don't await on the render path.
   void touchLastSeen(user.id)
 
-  const posts = await fetchFeed(user.id, { section })
+  const [posts, unreadDm] = await Promise.all([
+    fetchFeed(user.id, { section }),
+    fetchUnreadDmCount(user.id),
+  ])
+  const viewerCanDm = isNonAnon(user)
 
   return (
     <>
-      <Header active="feed" />
+      <Header active="feed" unreadDmCount={unreadDm} />
       <FeedRealtime />
+      <DmRealtime viewerId={user.id} />
       <main className="mx-auto w-full max-w-2xl px-4 py-4">
         <SectionTabs active={section} />
         <div className="mt-4 space-y-4">
@@ -53,7 +61,7 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
           ) : (
             <div className="space-y-3">
               {posts.map((post) => (
-                <PostCard key={post.id} post={post} viewerId={user.id} />
+                <PostCard key={post.id} post={post} viewerId={user.id} viewerCanDm={viewerCanDm} />
               ))}
             </div>
           )}

--- a/src/app/me/dm/[threadId]/page.tsx
+++ b/src/app/me/dm/[threadId]/page.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link'
+import { notFound, redirect } from 'next/navigation'
+import { getCurrentUser } from '@/lib/identity'
+import { getServerSupabase } from '@/lib/supabase/server'
+import { Header } from '@/components/Header'
+import { DmThreadView } from '@/components/DmThreadView'
+import { DmRealtime } from '@/components/DmRealtime'
+import { fetchThread, fetchUnreadDmCount } from '@/lib/queries/dm'
+import { isNonAnon } from '@/lib/dm'
+
+export const dynamic = 'force-dynamic'
+
+type Params = Promise<{ threadId: string }>
+
+export default async function DmThreadPage({ params }: { params: Params }) {
+  const user = await getCurrentUser()
+  if (!user) redirect('/')
+
+  const { threadId: raw } = await params
+  const threadId = Number(raw)
+  if (!Number.isInteger(threadId) || threadId <= 0) notFound()
+
+  const detail = await fetchThread(threadId, user.id)
+  if (!detail) notFound()
+
+  // 进入线程时把对方发来的未读全部置为已读。idempotent — 全部已读时
+  // 这次 update 命中 0 行。直接走 SQL 避开 server-action 的 redirect 逻辑。
+  const sb = getServerSupabase()
+  await sb
+    .from('dm_messages')
+    .update({ read_at: new Date().toISOString() })
+    .eq('thread_id', threadId)
+    .eq('sender_id', detail.other.id)
+    .is('read_at', null)
+
+  const unreadDm = await fetchUnreadDmCount(user.id)
+  const viewerCanSend = isNonAnon(user)
+  const viewerHasContact = (user.contact_handle ?? '').trim().length > 0
+
+  return (
+    <>
+      <Header active="me" unreadDmCount={unreadDm} />
+      <DmRealtime viewerId={user.id} />
+      <main className="mx-auto w-full max-w-2xl px-4 py-4">
+        <div className="mb-3 text-sm">
+          <Link href="/me" className="text-zinc-500 hover:text-zinc-800">
+            ← 我的私信
+          </Link>
+        </div>
+        <DmThreadView
+          threadId={threadId}
+          viewerId={user.id}
+          viewerCanSend={viewerCanSend}
+          viewerHasContact={viewerHasContact}
+          other={detail.other}
+          messages={detail.messages}
+        />
+      </main>
+    </>
+  )
+}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -6,9 +6,14 @@ import { PostCard } from '@/components/PostCard'
 import { ProfileForm } from '@/components/ProfileForm'
 import { RecoveryLink } from '@/components/RecoveryLink'
 import { LogoutButton } from '@/components/LogoutButton'
+import { DmThreadList } from '@/components/DmThreadList'
+import { DmRealtime } from '@/components/DmRealtime'
+import { MeRealtime } from '@/components/MeRealtime'
 import { fetchFeed } from '@/lib/queries/posts'
 import { fetchRepliesToMe, fetchMentionsOfMe, type ReplyToMe, type MentionOfMe } from '@/lib/queries/me'
+import { listMyThreads, fetchUnreadDmCount } from '@/lib/queries/dm'
 import { displayName, displayMeta } from '@/lib/display'
+import { isNonAnon } from '@/lib/dm'
 
 export const dynamic = 'force-dynamic'
 
@@ -16,15 +21,20 @@ export default async function MePage() {
   const user = await getCurrentUser()
   if (!user) redirect('/')
 
-  const [myPosts, repliesToMe, mentionsOfMe] = await Promise.all([
+  const [myPosts, repliesToMe, mentionsOfMe, threads, unreadDm] = await Promise.all([
     fetchFeed(user.id, { authorId: user.id, limit: 50 }),
     fetchRepliesToMe(user.id),
     fetchMentionsOfMe(user.id),
+    listMyThreads(user.id),
+    fetchUnreadDmCount(user.id),
   ])
+  const viewerCanDm = isNonAnon(user)
 
   return (
     <>
-      <Header active="me" />
+      <Header active="me" unreadDmCount={unreadDm} />
+      <DmRealtime viewerId={user.id} />
+      <MeRealtime viewerId={user.id} />
       <main className="mx-auto w-full max-w-2xl px-4 py-4">
         <div className="space-y-4">
           <ProfileForm
@@ -40,6 +50,10 @@ export default async function MePage() {
           <RecoveryLink uid={user.id} token={user.recovery_token} />
 
           <LogoutButton />
+
+          <Section title={`私信${unreadDm > 0 ? ` · 未读 ${unreadDm}` : ''}`}>
+            <DmThreadList threads={threads} viewerCanDm={viewerCanDm} viewerId={user.id} />
+          </Section>
 
           <Section title={`有人想找你 (${mentionsOfMe.length})`}>
             {mentionsOfMe.length === 0 ? (
@@ -71,7 +85,7 @@ export default async function MePage() {
             ) : (
               <div className="space-y-3">
                 {myPosts.map((post) => (
-                  <PostCard key={post.id} post={post} viewerId={user.id} />
+                  <PostCard key={post.id} post={post} viewerId={user.id} viewerCanDm={viewerCanDm} />
                 ))}
               </div>
             )}

--- a/src/components/DmButton.tsx
+++ b/src/components/DmButton.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { startThreadAction } from '@/lib/actions/dm'
+
+type Props = { toUserId: string }
+
+export function DmButton({ toUserId }: Props) {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
+  function onClick() {
+    setError(null)
+    startTransition(async () => {
+      const res = await startThreadAction(toUserId)
+      if (res.error || !res.threadId) {
+        setError(res.error ?? '打开私信失败')
+        return
+      }
+      router.push(`/me/dm/${res.threadId}`)
+    })
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={pending}
+        className="flex items-center gap-1 rounded-md px-2 py-1 text-sm text-zinc-500 transition-colors hover:bg-zinc-100 disabled:opacity-50"
+        aria-label="私信"
+      >
+        <span>✉</span>
+        <span>私信</span>
+      </button>
+      {error && <span className="text-xs text-red-600">{error}</span>}
+    </>
+  )
+}

--- a/src/components/DmRealtime.tsx
+++ b/src/components/DmRealtime.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { getBrowserSupabase } from '@/lib/supabase/client'
+
+const DEBOUNCE_MS = 500
+
+// 订阅 dm_notifications 上 recipient_id = me 的 INSERT。收到事件后
+// router.refresh() 重新拉服务端数据（线程列表 + 单线程页 + Header 红点）。
+//
+// 安全：dm_notifications 表只携 (recipient_id, thread_id) 元数据，没有
+// body / sender。dm_messages 不在 publication 里。详见 0012 migration 注释。
+type Props = { viewerId: string }
+export function DmRealtime({ viewerId }: Props) {
+  const router = useRouter()
+
+  useEffect(() => {
+    const sb = getBrowserSupabase()
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    function bump() {
+      if (timer) return
+      timer = setTimeout(() => {
+        timer = null
+        router.refresh()
+      }, DEBOUNCE_MS)
+    }
+
+    const channel = sb
+      .channel(`dm-inbox-${viewerId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'dm_notifications',
+          filter: `recipient_id=eq.${viewerId}`,
+        },
+        bump,
+      )
+      .subscribe()
+
+    return () => {
+      if (timer) clearTimeout(timer)
+      sb.removeChannel(channel)
+    }
+  }, [router, viewerId])
+
+  return null
+}

--- a/src/components/DmThreadList.tsx
+++ b/src/components/DmThreadList.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link'
+import { displayName, displayMeta } from '@/lib/display'
+import type { DmThreadSummary } from '@/lib/queries/dm'
+
+type Props = {
+  threads: DmThreadSummary[]
+  viewerCanDm: boolean
+  viewerId: string
+}
+
+export function DmThreadList({ threads, viewerCanDm, viewerId }: Props) {
+  if (!viewerCanDm) {
+    return (
+      <div className="rounded-xl border border-dashed border-zinc-300 bg-white px-4 py-6 text-center text-sm text-zinc-500">
+        到「我」设置昵称后才能开启私信
+      </div>
+    )
+  }
+  if (threads.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-zinc-300 bg-white px-4 py-6 text-center text-sm text-zinc-500">
+        还没有私信。在时间线点别人帖子的「私信」按钮可发起会话。
+      </div>
+    )
+  }
+  return (
+    <div className="space-y-2">
+      {threads.map((t) => (
+        <ThreadRow key={t.thread_id} thread={t} viewerId={viewerId} />
+      ))}
+    </div>
+  )
+}
+
+function ThreadRow({ thread, viewerId }: { thread: DmThreadSummary; viewerId: string }) {
+  const name = displayName(thread.other)
+  const meta = displayMeta(thread.other)
+  const last = thread.last_message
+  const lastSenderIsMe = last?.sender_id === viewerId
+  const previewPrefix = lastSenderIsMe ? '我：' : ''
+  const preview = last?.body ?? '（还没消息）'
+  return (
+    <Link
+      href={`/me/dm/${thread.thread_id}`}
+      className="flex items-baseline gap-2 rounded-xl border border-zinc-200 bg-white p-3 shadow-sm hover:border-zinc-300"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2 text-sm">
+          <span className="font-semibold text-zinc-900">{name}</span>
+          {meta && <span className="truncate text-zinc-500">· {meta}</span>}
+          {thread.other.is_vip && (
+            <span className="rounded-full bg-amber-100 px-1.5 py-px text-[10px] text-amber-800">
+              嘉宾
+            </span>
+          )}
+        </div>
+        <p className="mt-1 truncate text-xs text-zinc-600">
+          {previewPrefix}
+          {preview}
+        </p>
+      </div>
+      {thread.unread_count > 0 && (
+        <span className="shrink-0 rounded-full bg-rose-500 px-2 py-0.5 text-[11px] font-medium text-white">
+          {thread.unread_count > 99 ? '99+' : thread.unread_count}
+        </span>
+      )}
+    </Link>
+  )
+}

--- a/src/components/DmThreadView.tsx
+++ b/src/components/DmThreadView.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useEffect, useRef, useState, useTransition } from 'react'
+import { sendDmAction } from '@/lib/actions/dm'
+import { DM_MAX_CHARS } from '@/lib/constants'
+import { displayName, displayMeta } from '@/lib/display'
+import type { DmMessageRow, PublicUserDisplay } from '@/lib/types'
+
+type Props = {
+  threadId: number
+  viewerId: string
+  viewerCanSend: boolean
+  viewerHasContact: boolean
+  other: PublicUserDisplay
+  messages: DmMessageRow[]
+}
+
+export function DmThreadView({
+  threadId,
+  viewerId,
+  viewerCanSend,
+  viewerHasContact,
+  other,
+  messages,
+}: Props) {
+  const otherName = displayName(other)
+  const otherMeta = displayMeta(other)
+  const [body, setBody] = useState('')
+  const [reveal, setReveal] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [pending, startTransition] = useTransition()
+  const tail = useRef<HTMLDivElement | null>(null)
+
+  // 新消息到了滚到底
+  useEffect(() => {
+    tail.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+  }, [messages.length])
+
+  const remaining = DM_MAX_CHARS - body.length
+
+  function onSend() {
+    const trimmed = body.trim()
+    if (!trimmed) {
+      setError('说点啥再发吧')
+      return
+    }
+    if (trimmed.length > DM_MAX_CHARS) {
+      setError(`不能超过 ${DM_MAX_CHARS} 字`)
+      return
+    }
+    startTransition(async () => {
+      const res = await sendDmAction(threadId, trimmed, reveal && viewerHasContact)
+      if (res.error) {
+        setError(res.error)
+        return
+      }
+      setBody('')
+      setReveal(false)
+      setError(null)
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <header className="flex items-baseline gap-2 rounded-xl border border-zinc-200 bg-white px-3 py-2 text-sm">
+        <span className="font-semibold text-zinc-900">{otherName}</span>
+        {otherMeta && <span className="text-zinc-500">· {otherMeta}</span>}
+        {other.is_vip && (
+          <span className="rounded-full bg-amber-100 px-1.5 py-px text-[10px] text-amber-800">
+            嘉宾
+          </span>
+        )}
+      </header>
+
+      <div className="min-h-[40vh] space-y-2 rounded-xl border border-zinc-200 bg-white p-3">
+        {messages.length === 0 ? (
+          <p className="py-12 text-center text-sm text-zinc-500">还没消息，发第一条。</p>
+        ) : (
+          messages.map((m) => (
+            <MessageBubble key={m.id} message={m} mine={m.sender_id === viewerId} />
+          ))
+        )}
+        <div ref={tail} />
+      </div>
+
+      {viewerCanSend ? (
+        <div className="space-y-2 rounded-xl border border-zinc-200 bg-white p-3">
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            maxLength={DM_MAX_CHARS}
+            rows={3}
+            placeholder="说点什么…"
+            className="w-full resize-none rounded-md border border-zinc-200 bg-white px-3 py-2 text-[15px] focus:border-zinc-400 focus:outline-none"
+          />
+          <div className="flex items-center justify-between gap-2 text-xs">
+            <label
+              className={
+                'flex items-center gap-1.5 ' +
+                (viewerHasContact ? 'text-zinc-600' : 'cursor-not-allowed text-zinc-400')
+              }
+              title={viewerHasContact ? '' : '到「我」填写联系方式后才能附上'}
+            >
+              <input
+                type="checkbox"
+                checked={reveal && viewerHasContact}
+                onChange={(e) => setReveal(e.target.checked)}
+                disabled={!viewerHasContact}
+              />
+              本次发送附上我的联系方式
+            </label>
+            <div className="flex items-center gap-2">
+              <span className={remaining < 0 ? 'text-red-500' : 'text-zinc-400'}>
+                {remaining < 20 ? remaining : ''}
+              </span>
+              <button
+                type="button"
+                onClick={onSend}
+                disabled={pending || body.trim().length === 0 || remaining < 0}
+                className="rounded-md bg-zinc-900 px-3 py-1 text-xs font-medium text-white hover:bg-zinc-800 disabled:bg-zinc-300"
+              >
+                {pending ? '发送中…' : '发送'}
+              </button>
+            </div>
+          </div>
+          {error && <p className="text-xs text-red-600">{error}</p>}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-dashed border-zinc-300 bg-white px-4 py-4 text-center text-sm text-zinc-500">
+          请先到「我」页面设置昵称才能回复
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MessageBubble({ message, mine }: { message: DmMessageRow; mine: boolean }) {
+  return (
+    <div className={mine ? 'flex justify-end' : 'flex justify-start'}>
+      <div className={'max-w-[80%] space-y-1 ' + (mine ? 'text-right' : 'text-left')}>
+        <div
+          className={
+            'inline-block whitespace-pre-wrap rounded-2xl px-3 py-2 text-[15px] leading-relaxed ' +
+            (mine ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-800')
+          }
+        >
+          {message.body}
+        </div>
+        {message.revealed_contact && (
+          <div
+            className={
+              'inline-block rounded-md bg-amber-50 px-2 py-1 text-[11px] text-amber-800 ' +
+              (mine ? 'ml-auto' : '')
+            }
+          >
+            📞 {message.revealed_contact}
+          </div>
+        )}
+        <div className="text-[10px] text-zinc-400">{formatTime(message.created_at)}</div>
+      </div>
+    </div>
+  )
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Europe/Amsterdam',
+  })
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,9 +3,10 @@ import { EVENT_NAME } from '@/lib/constants'
 
 type Props = {
   active?: 'feed' | 'agenda' | 'me'
+  unreadDmCount?: number
 }
 
-export function Header({ active = 'feed' }: Props) {
+export function Header({ active = 'feed', unreadDmCount = 0 }: Props) {
   return (
     <header className="sticky top-0 z-30 border-b border-zinc-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/75">
       <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-3">
@@ -15,23 +16,38 @@ export function Header({ active = 'feed' }: Props) {
         <nav className="flex gap-1 text-sm">
           <NavTab href="/feed" label="时间线" active={active === 'feed'} />
           <NavTab href="/agenda" label="议程" active={active === 'agenda'} />
-          <NavTab href="/me" label="我" active={active === 'me'} />
+          <NavTab href="/me" label="我" active={active === 'me'} badge={unreadDmCount} />
         </nav>
       </div>
     </header>
   )
 }
 
-function NavTab({ href, label, active }: { href: string; label: string; active: boolean }) {
+function NavTab({
+  href,
+  label,
+  active,
+  badge = 0,
+}: {
+  href: string
+  label: string
+  active: boolean
+  badge?: number
+}) {
   return (
     <Link
       href={href}
       className={
-        'rounded-md px-2.5 py-1.5 transition-colors ' +
+        'relative rounded-md px-2.5 py-1.5 transition-colors ' +
         (active ? 'bg-zinc-900 text-white' : 'text-zinc-600 hover:bg-zinc-100')
       }
     >
       {label}
+      {badge > 0 && (
+        <span className="absolute -right-1 -top-1 inline-flex min-w-[18px] items-center justify-center rounded-full bg-rose-500 px-1 text-[10px] font-medium leading-[18px] text-white">
+          {badge > 99 ? '99+' : badge}
+        </span>
+      )}
     </Link>
   )
 }

--- a/src/components/MeRealtime.tsx
+++ b/src/components/MeRealtime.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { getBrowserSupabase } from '@/lib/supabase/client'
+
+const DEBOUNCE_MS = 500
+
+// /me 页 Realtime：新回复（含 AI 撮合 inline reply） + DM 通知 → router.refresh()。
+// 镜像 FeedRealtime 的 debounce 模式。
+//
+// 不订阅 post_match_intents：该表故意不在 supabase_realtime publication
+// 里（0011 物理隔离），订阅了也收不到事件。AI 撮合产生的"有人想找你"
+// 是写到 replies 表的 (is_ai=true, mentioned_user_id=me, visibility=author_only)，
+// 所以订阅 replies 就够。
+type Props = { viewerId: string }
+export function MeRealtime({ viewerId }: Props) {
+  const router = useRouter()
+
+  useEffect(() => {
+    const sb = getBrowserSupabase()
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    function bump() {
+      if (timer) return
+      timer = setTimeout(() => {
+        timer = null
+        router.refresh()
+      }, DEBOUNCE_MS)
+    }
+
+    const channel = sb
+      .channel(`me-${viewerId}`)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'replies' }, bump)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'dm_notifications',
+          filter: `recipient_id=eq.${viewerId}`,
+        },
+        bump,
+      )
+      .subscribe()
+
+    return () => {
+      if (timer) clearTimeout(timer)
+      sb.removeChannel(channel)
+    }
+  }, [router, viewerId])
+
+  return null
+}

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -8,15 +8,19 @@ import { deletePostAction, updatePostAction } from '@/lib/actions/posts'
 import { LikeButton } from './LikeButton'
 import { PollCard } from './PollCard'
 import { ReplySection } from './ReplySection'
+import { DmButton } from './DmButton'
 
-type Props = { post: FeedPost; viewerId: string }
+type Props = { post: FeedPost; viewerId: string; viewerCanDm: boolean }
 
-export function PostCard({ post, viewerId }: Props) {
+export function PostCard({ post, viewerId, viewerCanDm }: Props) {
   const author = post.author
   const name = displayName(author)
   const meta = displayMeta(author)
   const isPoll = post.type === 'poll'
   const isMine = post.user_id === viewerId
+  // 作者匿名（既无 nickname 又非 VIP）→ 无法接收 DM；按钮也藏起来。
+  const authorIsAnon = author.nickname === null && !author.is_vip
+  const canDm = viewerCanDm && !isMine && !authorIsAnon
 
   const [editing, setEditing] = useState(false)
   const [body, setBody] = useState(post.body)
@@ -183,6 +187,7 @@ export function PostCard({ post, viewerId }: Props) {
 
       <div className="mt-3 flex items-center gap-1">
         <LikeButton postId={post.id} count={post.like_count} liked={post.liked_by_me} />
+        {canDm && <DmButton toUserId={post.user_id} />}
       </div>
 
       <ReplySection postId={post.id} count={post.reply_count} replies={post.replies} viewerId={viewerId} />

--- a/src/lib/actions/dm.ts
+++ b/src/lib/actions/dm.ts
@@ -1,0 +1,147 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { getCurrentUser } from '@/lib/identity'
+import { getServerSupabase } from '@/lib/supabase/server'
+import { canonicalPair, isNonAnon } from '@/lib/dm'
+import { DM_MAX_CHARS } from '@/lib/constants'
+import type { DmThreadRow } from '@/lib/types'
+
+export type DmMutationResult = { error: string | null }
+export type StartThreadResult = { error: string | null; threadId?: number }
+
+export async function startThreadAction(toUserId: string): Promise<StartThreadResult> {
+  const viewer = await getCurrentUser()
+  if (!viewer) redirect('/')
+  if (!isNonAnon(viewer)) {
+    return { error: '请先到「我」页面设置昵称才能私信别人' }
+  }
+  if (typeof toUserId !== 'string' || toUserId.length < 32) {
+    return { error: '对方 id 不对' }
+  }
+  if (toUserId === viewer.id) {
+    return { error: '不能给自己发私信' }
+  }
+
+  const pair = canonicalPair(viewer.id, toUserId)
+  const sb = getServerSupabase()
+
+  const { data: existing, error: lookupErr } = await sb
+    .from('dm_threads')
+    .select('id')
+    .eq('user_low', pair.user_low)
+    .eq('user_high', pair.user_high)
+    .maybeSingle()
+
+  if (lookupErr) return { error: lookupErr.message }
+  if (existing) return { error: null, threadId: existing.id }
+
+  const { data: created, error: insertErr } = await sb
+    .from('dm_threads')
+    .insert(pair)
+    .select('id')
+    .single()
+
+  if (insertErr || !created) {
+    // 并发兼容：另一边可能刚 insert 了，撞 unique → 再查一次。
+    const { data: retry } = await sb
+      .from('dm_threads')
+      .select('id')
+      .eq('user_low', pair.user_low)
+      .eq('user_high', pair.user_high)
+      .maybeSingle()
+    if (retry) return { error: null, threadId: retry.id }
+    return { error: insertErr?.message ?? '创建线程失败' }
+  }
+
+  return { error: null, threadId: created.id }
+}
+
+export async function sendDmAction(
+  threadId: number,
+  body: string,
+  reveal: boolean,
+): Promise<DmMutationResult> {
+  const viewer = await getCurrentUser()
+  if (!viewer) redirect('/')
+  if (!isNonAnon(viewer)) {
+    return { error: '请先设置昵称才能发送私信' }
+  }
+  if (!Number.isInteger(threadId) || threadId <= 0) {
+    return { error: '线程 id 不对' }
+  }
+  const trimmed = String(body ?? '').trim()
+  if (!trimmed) return { error: '说点啥再发吧' }
+  if (trimmed.length > DM_MAX_CHARS) return { error: `不能超过 ${DM_MAX_CHARS} 字` }
+
+  const sb = getServerSupabase()
+  const other = await fetchThreadOtherParty(sb, threadId, viewer.id)
+  if (!other) return { error: '不是这个线程的成员' }
+
+  const revealedContact = reveal && viewer.contact_handle ? viewer.contact_handle : null
+
+  const { error: msgErr } = await sb.from('dm_messages').insert({
+    thread_id: threadId,
+    sender_id: viewer.id,
+    body: trimmed,
+    revealed_contact: revealedContact,
+  })
+  if (msgErr) return { error: msgErr.message }
+
+  // 通知 fan-out：单独表，进 publication，drives 接收方 Realtime。
+  // 失败不致命（消息已经入库），日志即可。
+  const { error: notifErr } = await sb.from('dm_notifications').insert({
+    recipient_id: other,
+    thread_id: threadId,
+  })
+  if (notifErr) {
+    console.error('dm_notifications insert failed:', notifErr.message)
+  }
+
+  revalidatePath(`/me/dm/${threadId}`)
+  revalidatePath('/me')
+  return { error: null }
+}
+
+export async function markDmReadAction(threadId: number): Promise<DmMutationResult> {
+  const viewer = await getCurrentUser()
+  if (!viewer) redirect('/')
+  if (!Number.isInteger(threadId) || threadId <= 0) return { error: '线程 id 不对' }
+
+  const sb = getServerSupabase()
+  const other = await fetchThreadOtherParty(sb, threadId, viewer.id)
+  if (!other) return { error: '不是这个线程的成员' }
+
+  const { error } = await sb
+    .from('dm_messages')
+    .update({ read_at: new Date().toISOString() })
+    .eq('thread_id', threadId)
+    .eq('sender_id', other)
+    .is('read_at', null)
+
+  if (error) return { error: error.message }
+
+  revalidatePath(`/me/dm/${threadId}`)
+  revalidatePath('/me')
+  return { error: null }
+}
+
+// 查 thread 双方，返回"对方"的 user id。viewer 不是成员则返回 null。
+type ServerSupabase = ReturnType<typeof getServerSupabase>
+async function fetchThreadOtherParty(
+  sb: ServerSupabase,
+  threadId: number,
+  viewerId: string,
+): Promise<string | null> {
+  const { data } = await sb
+    .from('dm_threads')
+    .select('user_low, user_high')
+    .eq('id', threadId)
+    .maybeSingle()
+  if (!data) return null
+  const t = data as Pick<DmThreadRow, 'user_low' | 'user_high'>
+  if (t.user_low === viewerId) return t.user_high
+  if (t.user_high === viewerId) return t.user_low
+  return null
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,6 +5,7 @@ export const EVENT_END_ISO = process.env.NEXT_PUBLIC_EVENT_END ?? '2026-05-09T18
 
 export const POST_MAX_CHARS = 300
 export const REPLY_MAX_CHARS = 300
+export const DM_MAX_CHARS = 300
 export const POLL_MAX_OPTIONS = 6
 export const POLL_MIN_OPTIONS = 2
 export const MATCH_INTENT_MAX_CHARS = 200

--- a/src/lib/dm.test.ts
+++ b/src/lib/dm.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { canonicalPair, isNonAnon } from './dm'
+
+describe('canonicalPair', () => {
+  it('orders by string comparison so the pair is symmetric', () => {
+    const a = '11111111-1111-1111-1111-111111111111'
+    const b = '22222222-2222-2222-2222-222222222222'
+    expect(canonicalPair(a, b)).toEqual({ user_low: a, user_high: b })
+    expect(canonicalPair(b, a)).toEqual({ user_low: a, user_high: b })
+  })
+
+  it('rejects self DM', () => {
+    const a = '11111111-1111-1111-1111-111111111111'
+    expect(() => canonicalPair(a, a)).toThrow()
+  })
+})
+
+describe('isNonAnon', () => {
+  it('user with nickname is non-anon', () => {
+    expect(isNonAnon({ nickname: 'alice', is_vip: false })).toBe(true)
+  })
+
+  it('VIP without nickname is non-anon (fallback to vip_name)', () => {
+    expect(isNonAnon({ nickname: null, is_vip: true })).toBe(true)
+  })
+
+  it('no nickname, not VIP -> anon', () => {
+    expect(isNonAnon({ nickname: null, is_vip: false })).toBe(false)
+  })
+})

--- a/src/lib/dm.ts
+++ b/src/lib/dm.ts
@@ -1,0 +1,19 @@
+import type { UserRow } from './types'
+
+// dm_threads 用 (user_low, user_high) 加 user_low < user_high 约束保证
+// 一对用户只能存在一个 thread。所有插入/查找都要先把 (a, b) 规整成
+// canonical 顺序。
+export type CanonicalPair = { user_low: string; user_high: string }
+
+export function canonicalPair(a: string, b: string): CanonicalPair {
+  if (a === b) throw new Error('cannot DM yourself')
+  return a < b ? { user_low: a, user_high: b } : { user_low: b, user_high: a }
+}
+
+// "非匿名"=有自填昵称，或是嘉宾。决策来自 issue #6 用户答复 5：
+// 匿名者既不能发起也不能回复 DM；嘉宾即使没填 nickname 也算非匿名
+// （会 fallback 到 vip_name 显示）。
+type NonAnonCheck = Pick<UserRow, 'nickname' | 'is_vip'>
+export function isNonAnon(u: NonAnonCheck): boolean {
+  return u.nickname !== null || u.is_vip
+}

--- a/src/lib/queries/dm.ts
+++ b/src/lib/queries/dm.ts
@@ -1,0 +1,163 @@
+import 'server-only'
+import { getServerSupabase } from '@/lib/supabase/server'
+import type { DmMessageRow, PublicUserDisplay } from '@/lib/types'
+
+export type DmThreadSummary = {
+  thread_id: number
+  other: PublicUserDisplay
+  last_message: { body: string; created_at: string; sender_id: string } | null
+  unread_count: number
+}
+
+export type DmThreadDetail = {
+  thread_id: number
+  other: PublicUserDisplay
+  messages: DmMessageRow[]
+}
+
+const PUBLIC_USER_FIELDS =
+  'id, nickname, company, contact_handle, show_contact, is_vip, vip_name, vip_title'
+
+// 我参与的所有线程，按最后一条消息时间倒序。
+export async function listMyThreads(viewerId: string): Promise<DmThreadSummary[]> {
+  const sb = getServerSupabase()
+
+  const { data: threads } = await sb
+    .from('dm_threads')
+    .select('id, user_low, user_high')
+    .or(`user_low.eq.${viewerId},user_high.eq.${viewerId}`)
+
+  if (!threads || threads.length === 0) return []
+
+  const threadIds = threads.map((t) => t.id)
+  const otherIds = threads.map((t) => (t.user_low === viewerId ? t.user_high : t.user_low))
+
+  const [{ data: msgs }, { data: users }] = await Promise.all([
+    sb
+      .from('dm_messages')
+      .select('id, thread_id, sender_id, body, read_at, created_at')
+      .in('thread_id', threadIds)
+      .order('created_at', { ascending: false }),
+    sb
+      .from('public_user_display')
+      .select(PUBLIC_USER_FIELDS)
+      .in('id', otherIds),
+  ])
+
+  const userById = new Map<string, PublicUserDisplay>()
+  for (const u of (users ?? []) as PublicUserDisplay[]) userById.set(u.id, u)
+
+  const lastByThread = new Map<number, { body: string; created_at: string; sender_id: string }>()
+  const unreadByThread = new Map<number, number>()
+  for (const m of (msgs ?? []) as Pick<
+    DmMessageRow,
+    'thread_id' | 'sender_id' | 'body' | 'read_at' | 'created_at'
+  >[]) {
+    if (!lastByThread.has(m.thread_id)) {
+      lastByThread.set(m.thread_id, {
+        body: m.body,
+        created_at: m.created_at,
+        sender_id: m.sender_id,
+      })
+    }
+    if (m.sender_id !== viewerId && m.read_at === null) {
+      unreadByThread.set(m.thread_id, (unreadByThread.get(m.thread_id) ?? 0) + 1)
+    }
+  }
+
+  const summaries: DmThreadSummary[] = threads.map((t) => {
+    const otherId = t.user_low === viewerId ? t.user_high : t.user_low
+    const other =
+      userById.get(otherId) ??
+      ({
+        id: otherId,
+        nickname: null,
+        company: null,
+        contact_handle: null,
+        show_contact: false,
+        is_vip: false,
+        vip_name: null,
+        vip_title: null,
+      } satisfies PublicUserDisplay)
+    return {
+      thread_id: t.id,
+      other,
+      last_message: lastByThread.get(t.id) ?? null,
+      unread_count: unreadByThread.get(t.id) ?? 0,
+    }
+  })
+
+  // 按最后一条消息倒序；从未发过消息的线程沉底。
+  summaries.sort((a, b) => {
+    const ta = a.last_message?.created_at ?? ''
+    const tb = b.last_message?.created_at ?? ''
+    if (ta === tb) return 0
+    return ta < tb ? 1 : -1
+  })
+
+  return summaries
+}
+
+export async function fetchThread(
+  threadId: number,
+  viewerId: string,
+): Promise<DmThreadDetail | null> {
+  const sb = getServerSupabase()
+  const { data: thread } = await sb
+    .from('dm_threads')
+    .select('id, user_low, user_high')
+    .eq('id', threadId)
+    .maybeSingle()
+  if (!thread) return null
+  if (thread.user_low !== viewerId && thread.user_high !== viewerId) return null
+
+  const otherId = thread.user_low === viewerId ? thread.user_high : thread.user_low
+
+  const [{ data: messages }, { data: other }] = await Promise.all([
+    sb
+      .from('dm_messages')
+      .select('*')
+      .eq('thread_id', threadId)
+      .order('created_at', { ascending: true }),
+    sb
+      .from('public_user_display')
+      .select(PUBLIC_USER_FIELDS)
+      .eq('id', otherId)
+      .maybeSingle(),
+  ])
+
+  return {
+    thread_id: threadId,
+    other: (other ?? {
+      id: otherId,
+      nickname: null,
+      company: null,
+      contact_handle: null,
+      show_contact: false,
+      is_vip: false,
+      vip_name: null,
+      vip_title: null,
+    }) as PublicUserDisplay,
+    messages: (messages ?? []) as DmMessageRow[],
+  }
+}
+
+export async function fetchUnreadDmCount(viewerId: string): Promise<number> {
+  const sb = getServerSupabase()
+  // 找出我参与的 threadIds，再 count 对方发来未读。
+  const { data: threads } = await sb
+    .from('dm_threads')
+    .select('id, user_low, user_high')
+    .or(`user_low.eq.${viewerId},user_high.eq.${viewerId}`)
+  if (!threads || threads.length === 0) return 0
+
+  const threadIds = threads.map((t) => t.id)
+  const { count } = await sb
+    .from('dm_messages')
+    .select('id', { count: 'exact', head: true })
+    .in('thread_id', threadIds)
+    .neq('sender_id', viewerId)
+    .is('read_at', null)
+
+  return count ?? 0
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -81,3 +81,30 @@ export type PublicUserDisplay = Pick<
   UserRow,
   'id' | 'nickname' | 'company' | 'contact_handle' | 'show_contact' | 'is_vip' | 'vip_name' | 'vip_title'
 >
+
+// =====================================================================
+// DM (migration 0012)
+// =====================================================================
+export type DmThreadRow = {
+  id: number
+  user_low: string
+  user_high: string
+  created_at: string
+}
+
+export type DmMessageRow = {
+  id: number
+  thread_id: number
+  sender_id: string
+  body: string
+  revealed_contact: string | null
+  read_at: string | null
+  created_at: string
+}
+
+export type DmNotificationRow = {
+  id: number
+  recipient_id: string
+  thread_id: number
+  created_at: string
+}

--- a/supabase/migrations/0012_dm.sql
+++ b/supabase/migrations/0012_dm.sql
@@ -1,0 +1,71 @@
+-- =====================================================================
+-- 0012_dm.sql — 站内信 (issue #6, scope C)
+-- =====================================================================
+-- 1-on-1 DM 线程 + 消息 + Realtime 通知 fan-out。
+--
+-- 安全设计（关键）：项目刻意不用 Supabase Auth，客户端只持 anon key，
+-- 因此 Realtime 无法基于 RLS 做"按用户过滤"。否则两条路都不通：
+--   - 把 dm_messages 进 publication + anon read → 任何人能拉所有 DM
+--   - 不进 publication / RLS deny → 接收方收不到 Realtime 事件
+--
+-- 采用 fan-out：dm_messages 物理私密（不进 publication，RLS deny anon），
+-- 单独的 dm_notifications 表只携 (recipient_id, thread_id) 元数据，进
+-- publication，anon 可读。客户端订阅自己的 recipient_id，收到事件后用
+-- 服务端 action 走 cookie 鉴权再拉真正消息体。
+--
+-- 残余暴露：anon attacker 若全表订阅 dm_notifications 能看到"用户 X 在
+-- 时刻 T 在 thread Z 收到一条 DM"——拿不到内容、发送方、对方身份。可
+-- 接受（与 F'' 方案 anon 能见 post_id 但不能见 match_intent 同等级）。
+
+-- 1. threads
+create table dm_threads (
+  id bigserial primary key,
+  user_low  uuid not null references users(id) on delete cascade,
+  user_high uuid not null references users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique (user_low, user_high),
+  check (user_low < user_high)
+);
+
+create index dm_threads_user_low_idx  on dm_threads (user_low);
+create index dm_threads_user_high_idx on dm_threads (user_high);
+
+-- 2. messages
+create table dm_messages (
+  id bigserial primary key,
+  thread_id bigint not null references dm_threads(id) on delete cascade,
+  sender_id uuid not null references users(id) on delete cascade,
+  body text not null check (char_length(body) <= 300),
+  revealed_contact text,
+  read_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index dm_messages_thread_idx on dm_messages (thread_id, created_at);
+create index dm_messages_unread_idx on dm_messages (thread_id, sender_id) where read_at is null;
+
+-- 3. fan-out for realtime
+create table dm_notifications (
+  id bigserial primary key,
+  recipient_id uuid not null references users(id) on delete cascade,
+  thread_id bigint not null references dm_threads(id) on delete cascade,
+  created_at timestamptz not null default now()
+);
+
+create index dm_notifications_recipient_idx on dm_notifications (recipient_id, created_at desc);
+
+-- 4. RLS
+alter table dm_threads        enable row level security;
+alter table dm_messages       enable row level security;
+alter table dm_notifications  enable row level security;
+
+-- threads / messages：不写任何 anon policy = 默认全拒。service_role 不受 RLS。
+-- notifications：anon 可读（只含 recipient_id + thread_id 元数据）
+create policy "anon read dm_notifications" on dm_notifications
+  for select to anon using (true);
+
+-- 5. 仅 notifications 进 publication
+alter publication supabase_realtime add table dm_notifications;
+
+-- 部署后必须 Dashboard → Database → Replication 把 dm_notifications toggle 一下，
+-- 否则 ALTER PUBLICATION 不会触发 Realtime 重载（PR #7 验证过的坑）。


### PR DESCRIPTION
Closes #6.

## Summary
- 完整 1-on-1 站内信：线程 + 多轮 + 未读红点 + 可选 contact 一次性释放
- Realtime：消息秒到对方 Header（无需刷新）
- 匿名用户既不能发起也不能回复（按 issue #6 用户决策 5）；嘉宾即使无 nickname 也算非匿名
- 顺手补 Phase 2 余项：`/me` 接 Realtime（新回复 / AI 撮合实时进）

## 关键架构决策
项目刻意不用 Supabase Auth，anon 客户端没 JWT，Realtime 没法按 viewer 过滤 RLS。两条天然路都不通：
- `dm_messages` + anon read → 任何人能拉所有 DM
- `dm_messages` 不在 publication / RLS deny → 接收方收不到事件

采用 fan-out（mirror 0011 物理隔离思路）：
- `dm_messages` RLS deny anon、不在 publication → 内容 100% 私密，仅服务端 service_role 按 cookie 鉴权读
- `dm_notifications(recipient_id, thread_id, created_at)` 进 publication，anon 可读
- 客户端订阅 `recipient_id=eq.<my_uid>`，收到事件 → `router.refresh()` 走服务端拉真消息

**残余暴露**：anon attacker 全表订阅 `dm_notifications` 能看到 metadata（"用户 X 在 T 时刻收到 DM 属于 thread Z"），看不到内容/发送方/对方身份。等同于 F'' 方案 anon 见 post_id 不见 match_intent。

## 部署 ⚠️
1. 跑 \`supabase/migrations/0012_dm.sql\`
2. Supabase Dashboard → Database → Replication，把 \`dm_notifications\` toggle 一下（否则 ALTER PUBLICATION 不会触发 Realtime 重载，PR #7 验证过的坑）

## Test plan
- [ ] tsc / eslint / vitest 全绿（已在本地通过：6 files / 44 tests）
- [ ] 两浏览器（A、B 都非匿名）+ 隐身窗口 C 匿名
  - [ ] A 在 B 帖子上点"私信" → 跳到 /me/dm/[id] 写一句发出
  - [ ] B 的 Header "我" tab 出现红点 1（**Realtime**，不刷新）
  - [ ] B 进 /me 看到线程 + 未读 1，进线程页 → 红点消失
  - [ ] B 回复 → A 的线程页消息流秒进
  - [ ] A 勾选"附上联系方式"发一条 → B 看到联系方式条
  - [ ] C（匿名）打开 A 的帖子 → 看不到"私信"按钮
  - [ ] C 直接 GET `/me/dm/[A-B-thread]` → 404
  - [ ] VIP D（无 nickname）→ 能发起 DM
- [ ] /me Realtime：另一浏览器回复我的帖子 → 我的 /me 实时进新回复

## 不在本 PR
- Push / email 通知（明确 out of scope）
- 群聊、消息撤回、消息编辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)