### PR TITLE
feat(screen): 大屏新交互 — 默认骨架 + 嘉宾 QA + 抽奖 (#27)

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -3,6 +3,7 @@ import { getCurrentUser, touchLastSeen } from '@/lib/identity'
 import { Header } from '@/components/Header'
 import { EventHero } from '@/components/EventHero'
 import { PostComposer } from '@/components/PostComposer'
+import { QuestionComposer } from '@/components/QuestionComposer'
 import { PostCard } from '@/components/PostCard'
 import { SectionTabs } from '@/components/SectionTabs'
 import { SectionContextBar } from '@/components/SectionContextBar'
@@ -11,7 +12,7 @@ import { FeedRealtime } from '@/components/FeedRealtime'
 import { DmRealtime } from '@/components/DmRealtime'
 import { fetchFeed } from '@/lib/queries/posts'
 import { fetchUnreadMe } from '@/lib/queries/unread'
-import { getCurrentSection } from '@/lib/queries/event-state'
+import { getCurrentSection, getScreenModeState } from '@/lib/queries/event-state'
 import { isNonAnon } from '@/lib/dm'
 import { DEFAULT_SECTION, isSectionId } from '@/lib/sections'
 
@@ -30,7 +31,10 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
 
   // 「当前板块」= 主办方覆写 → 议程时间表 → null（活动外 / 空档）。
   // 用于 (a) /feed 默认跳当前板块；(b) SectionTabs LIVE 标。
-  const liveSection = await getCurrentSection()
+  const [liveSection, modeState] = await Promise.all([
+    getCurrentSection(),
+    getScreenModeState(),
+  ])
 
   // 没传 ?section= 时跳到当前板块；活动外则用默认 p1。
   const section = isSectionId(sp.section)
@@ -60,6 +64,14 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
         <SectionContextBar section={section} />
         <div className="mt-4 space-y-4">
           <OnboardingBanner />
+          {modeState.mode === 'qa' && modeState.qa_host_name && (
+            <QuestionComposer
+              hostName={modeState.qa_host_name}
+              hostTitle={modeState.qa_host_title}
+              defaultNickname={user.nickname}
+              defaultCompany={user.company}
+            />
+          )}
           <PostComposer
             defaultNickname={user.nickname}
             defaultCompany={user.company}

--- a/src/app/screen/page.tsx
+++ b/src/app/screen/page.tsx
@@ -2,7 +2,11 @@ import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { readAdminCookie, setAdminCookie } from '@/lib/identity'
 import { fetchScreenData } from '@/lib/actions/screen'
-import { getCurrentSection } from '@/lib/queries/event-state'
+import {
+  getCurrentSection,
+  getScreenModeState,
+  listVipUsers,
+} from '@/lib/queries/event-state'
 import { QRCode } from '@/components/QRCode'
 import { ScreenView } from '@/components/screen/ScreenView'
 import { ScreenAdminBar } from '@/components/screen/ScreenAdminBar'
@@ -30,10 +34,12 @@ export default async function ScreenPage({
 
   const section = isSectionId(sp.section) ? sp.section : null
 
-  const [snap, h, currentSection] = await Promise.all([
+  const [snap, h, currentSection, modeState, vips] = await Promise.all([
     fetchScreenData(section),
     headers(),
     getCurrentSection(),
+    getScreenModeState(),
+    listVipUsers(),
   ])
 
   const host = h.get('x-forwarded-host') ?? h.get('host') ?? ''
@@ -53,13 +59,19 @@ export default async function ScreenPage({
         key={section ?? 'all'}
         initialPosts={snap.posts}
         initialOnline={snap.online}
+        initialMode={modeState}
         eventName={EVENT_NAME}
         section={section}
         liveSection={currentSection}
         password={password}
         qrSlot={<QRCode value={qrUrl} size={280} />}
       />
-      <ScreenAdminBar currentSection={currentSection} />
+      <ScreenAdminBar
+        currentSection={currentSection}
+        screenMode={modeState.mode}
+        qaHostUserId={modeState.qa_host_user_id}
+        vips={vips}
+      />
     </>
   )
 }

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -8,7 +8,7 @@ type Props = {
     is_vip: boolean
     vip_name: string | null
   }
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl'
   // 暗背景下使用（如 /screen），文字仍是白色但 ring 色变深。
   onDark?: boolean
 }
@@ -19,6 +19,8 @@ const SIZE_CLS: Record<NonNullable<Props['size']>, string> = {
   md: 'size-9 text-sm',
   lg: 'size-11 text-base',
   xl: 'size-16 text-2xl',
+  '2xl': 'size-32 text-5xl',
+  '3xl': 'size-56 text-8xl',
 }
 
 export function Avatar({ seed, user, size = 'md', onDark = false }: Props) {

--- a/src/components/FeedRealtime.tsx
+++ b/src/components/FeedRealtime.tsx
@@ -41,6 +41,7 @@ export function FeedRealtime() {
       .on('postgres_changes', { event: '*', schema: 'public', table: 'replies' }, bump)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'likes' }, bump)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'poll_votes' }, bump)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'event_state' }, bump)
       .subscribe()
 
     return () => {

--- a/src/components/QuestionComposer.tsx
+++ b/src/components/QuestionComposer.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useActionState, useEffect, useRef, useState } from 'react'
+import { Mic } from 'lucide-react'
+import { createQuestionAction, type PostFormState } from '@/lib/actions/posts'
+import { POST_MAX_CHARS } from '@/lib/constants'
+
+const initial: PostFormState = { error: null }
+
+type Props = {
+  hostName: string
+  hostTitle: string | null
+  defaultNickname: string | null
+  defaultCompany: string | null
+}
+
+// 观众端 QA 提问入口。仅在 event_state.screen_mode='qa' 时由 /feed 渲染在
+// PostComposer 上方。设计上和 PostComposer 同样走 uncontrolled form +
+// React 19 form action（iPhone Chrome 上 onSubmit 会被 hydration 失败掐死，
+// progressive enhancement 是兜底）。
+export function QuestionComposer({
+  hostName,
+  hostTitle,
+  defaultNickname,
+  defaultCompany,
+}: Props) {
+  const [state, formAction, isPending] = useActionState(createQuestionAction, initial)
+  const [bodyLen, setBodyLen] = useState(0)
+  const [identityOpen, setIdentityOpen] = useState(false)
+  const formRef = useRef<HTMLFormElement>(null)
+
+  useEffect(() => {
+    if (!state.ok) return
+    formRef.current?.reset()
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- mirrors PostComposer
+    setBodyLen(0)
+  }, [state])
+
+  const remaining = POST_MAX_CHARS - bodyLen
+
+  return (
+    <form
+      ref={formRef}
+      action={formAction}
+      className="space-y-3 rounded-2xl border-2 border-rose-300 bg-rose-50/60 p-4 shadow-sm"
+    >
+      <div className="flex items-start gap-2">
+        <Mic className="mt-0.5 size-4 shrink-0 text-rose-600" aria-hidden />
+        <div className="flex-1 leading-tight">
+          <p className="text-sm font-semibold text-rose-900">
+            向「{hostName}」提问
+            {hostTitle && <span className="ml-1 text-xs font-normal text-rose-700">· {hostTitle}</span>}
+          </p>
+          <p className="mt-0.5 text-xs text-rose-700">
+            提问会在大屏滚动展示，按点赞排序。嘉宾会从大屏读到。
+          </p>
+        </div>
+      </div>
+
+      <textarea
+        name="body"
+        defaultValue=""
+        onInput={(e) => setBodyLen(e.currentTarget.value.length)}
+        maxLength={POST_MAX_CHARS}
+        placeholder={`想问 ${hostName} 什么？`}
+        rows={3}
+        className="w-full resize-none rounded-md border border-rose-200 bg-white p-2.5 text-base text-zinc-900 placeholder:text-zinc-400 focus:border-rose-400 focus:outline-none"
+      />
+
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-zinc-500">
+        <button
+          type="button"
+          onClick={() => setIdentityOpen((v) => !v)}
+          className="rounded-md px-2 py-1 text-rose-700 hover:bg-rose-100"
+        >
+          {defaultNickname ? defaultNickname : '匿名'}
+          {defaultCompany && ` · ${defaultCompany}`}
+          <span className="ml-1 text-zinc-400">{identityOpen ? '收起' : '编辑身份'}</span>
+        </button>
+        <span className={remaining < 0 ? 'text-red-500' : ''}>{remaining}</span>
+      </div>
+
+      {identityOpen && (
+        <div className="grid grid-cols-1 gap-2 rounded-lg bg-white/70 p-3 sm:grid-cols-2">
+          <input
+            name="nickname"
+            defaultValue={defaultNickname ?? ''}
+            placeholder="昵称（留空显示为匿名）"
+            className="rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-rose-400"
+          />
+          <input
+            name="company"
+            defaultValue={defaultCompany ?? ''}
+            placeholder="公司"
+            className="rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-rose-400"
+          />
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-lg bg-rose-600 px-4 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-rose-700 disabled:bg-zinc-400"
+        >
+          {isPending ? '发送中…' : '提问'}
+        </button>
+      </div>
+
+      {state.error && <p className="text-sm text-red-600">{state.error}</p>}
+    </form>
+  )
+}

--- a/src/components/screen/ScreenAdminBar.tsx
+++ b/src/components/screen/ScreenAdminBar.tsx
@@ -6,16 +6,23 @@ import { Settings, X } from 'lucide-react'
 import {
   setCurrentSectionAction,
   clearCurrentSectionAction,
+  startQaAction,
+  exitScreenModeAction,
 } from '@/lib/actions/event-state'
 import { SECTIONS, isSectionId, type SectionId } from '@/lib/sections'
+import type { ScreenMode } from '@/lib/types'
+import type { VipForDropdown } from '@/lib/queries/event-state'
 
 type Props = {
   currentSection: SectionId | null
+  screenMode: ScreenMode
+  qaHostUserId: string | null
+  vips: VipForDropdown[]
 }
 
 // /screen 右下角浮动控制条 — 只主办方（admin cookie 已 set）能看到。
 // 投影时如果是镜像屏，控制条会被一起投出去，所以默认折叠成一个小图标。
-export function ScreenAdminBar({ currentSection }: Props) {
+export function ScreenAdminBar({ currentSection, screenMode, qaHostUserId, vips }: Props) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const filterRaw = searchParams.get('section')
@@ -24,6 +31,7 @@ export function ScreenAdminBar({ currentSection }: Props) {
   const [open, setOpen] = useState(false)
   const [pending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
+  const [pendingHostId, setPendingHostId] = useState<string>(qaHostUserId ?? vips[0]?.user_id ?? '')
 
   function pickSection(id: SectionId) {
     setError(null)
@@ -43,6 +51,26 @@ export function ScreenAdminBar({ currentSection }: Props) {
 
   function setFilter(id: SectionId | null) {
     router.push(id ? `/screen?section=${id}` : '/screen')
+  }
+
+  function startQa() {
+    if (!pendingHostId) {
+      setError('请先选择嘉宾')
+      return
+    }
+    setError(null)
+    startTransition(async () => {
+      const res = await startQaAction(pendingHostId)
+      if (res.error) setError(res.error)
+    })
+  }
+
+  function exitMode() {
+    setError(null)
+    startTransition(async () => {
+      const res = await exitScreenModeAction()
+      if (res.error) setError(res.error)
+    })
   }
 
   if (!open) {
@@ -73,6 +101,61 @@ export function ScreenAdminBar({ currentSection }: Props) {
       </div>
 
       <div className="space-y-3">
+        {/* 0. 大屏模式 — QA / 抽奖 / 默认骨架。优先级最高放最上面，活动期间常用 */}
+        <fieldset>
+          <legend className="mb-1.5 text-[11px] font-medium uppercase tracking-wider text-zinc-400">
+            大屏模式
+          </legend>
+          <p className="mb-1.5 text-xs">
+            <span className="text-zinc-100">
+              当前：
+              {screenMode === 'qa'
+                ? `QA · ${vips.find((v) => v.user_id === qaHostUserId)?.name ?? '?'}`
+                : screenMode === 'lottery'
+                  ? '抽奖'
+                  : '默认骨架'}
+            </span>
+          </p>
+          {screenMode === 'default' ? (
+            <div className="space-y-1.5">
+              <label className="block text-[11px] text-zinc-400">
+                嘉宾 QA — 选目标嘉宾后开始
+              </label>
+              <select
+                value={pendingHostId}
+                onChange={(e) => setPendingHostId(e.target.value)}
+                disabled={pending || vips.length === 0}
+                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1.5 text-xs text-zinc-100 disabled:opacity-50"
+              >
+                {vips.length === 0 && <option value="">（暂无 VIP 已登录）</option>}
+                {vips.map((v) => (
+                  <option key={v.user_id} value={v.user_id}>
+                    {v.name}
+                    {v.title ? ` · ${v.title}` : ''}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={startQa}
+                disabled={pending || !pendingHostId}
+                className="w-full rounded-md bg-rose-500 px-2 py-1.5 text-xs font-medium text-white hover:bg-rose-400 disabled:opacity-50"
+              >
+                开始 QA
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={exitMode}
+              disabled={pending}
+              className="w-full rounded-md bg-zinc-700 px-2 py-1.5 text-xs font-medium text-zinc-100 hover:bg-zinc-600 disabled:opacity-50"
+            >
+              {screenMode === 'qa' ? '结束 QA' : '结束抽奖'}（回默认骨架）
+            </button>
+          )}
+        </fieldset>
+
         {/* 1. 设置当前 LIVE 板块 — 影响 /feed 的 LIVE 红标 + EventHero */}
         <fieldset>
           <legend className="mb-1.5 text-[11px] font-medium uppercase tracking-wider text-zinc-400">

--- a/src/components/screen/ScreenAdminBar.tsx
+++ b/src/components/screen/ScreenAdminBar.tsx
@@ -8,6 +8,7 @@ import {
   clearCurrentSectionAction,
   startQaAction,
   exitScreenModeAction,
+  startLotteryAction,
 } from '@/lib/actions/event-state'
 import { SECTIONS, isSectionId, type SectionId } from '@/lib/sections'
 import type { ScreenMode } from '@/lib/types'
@@ -32,6 +33,8 @@ export function ScreenAdminBar({ currentSection, screenMode, qaHostUserId, vips 
   const [pending, startTransition] = useTransition()
   const [error, setError] = useState<string | null>(null)
   const [pendingHostId, setPendingHostId] = useState<string>(qaHostUserId ?? vips[0]?.user_id ?? '')
+  const [mustHavePosted, setMustHavePosted] = useState(false)
+  const [excludePreviousWinners, setExcludePreviousWinners] = useState(true)
 
   function pickSection(id: SectionId) {
     setError(null)
@@ -69,6 +72,17 @@ export function ScreenAdminBar({ currentSection, screenMode, qaHostUserId, vips 
     setError(null)
     startTransition(async () => {
       const res = await exitScreenModeAction()
+      if (res.error) setError(res.error)
+    })
+  }
+
+  function startLottery() {
+    setError(null)
+    startTransition(async () => {
+      const res = await startLotteryAction({
+        must_have_posted: mustHavePosted,
+        exclude_previous_winners: excludePreviousWinners,
+      })
       if (res.error) setError(res.error)
     })
   }
@@ -117,32 +131,64 @@ export function ScreenAdminBar({ currentSection, screenMode, qaHostUserId, vips 
             </span>
           </p>
           {screenMode === 'default' ? (
-            <div className="space-y-1.5">
-              <label className="block text-[11px] text-zinc-400">
-                嘉宾 QA — 选目标嘉宾后开始
-              </label>
-              <select
-                value={pendingHostId}
-                onChange={(e) => setPendingHostId(e.target.value)}
-                disabled={pending || vips.length === 0}
-                className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1.5 text-xs text-zinc-100 disabled:opacity-50"
-              >
-                {vips.length === 0 && <option value="">（暂无 VIP 已登录）</option>}
-                {vips.map((v) => (
-                  <option key={v.user_id} value={v.user_id}>
-                    {v.name}
-                    {v.title ? ` · ${v.title}` : ''}
-                  </option>
-                ))}
-              </select>
-              <button
-                type="button"
-                onClick={startQa}
-                disabled={pending || !pendingHostId}
-                className="w-full rounded-md bg-rose-500 px-2 py-1.5 text-xs font-medium text-white hover:bg-rose-400 disabled:opacity-50"
-              >
-                开始 QA
-              </button>
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <label className="block text-[11px] text-zinc-400">
+                  嘉宾 QA — 选目标嘉宾后开始
+                </label>
+                <select
+                  value={pendingHostId}
+                  onChange={(e) => setPendingHostId(e.target.value)}
+                  disabled={pending || vips.length === 0}
+                  className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1.5 text-xs text-zinc-100 disabled:opacity-50"
+                >
+                  {vips.length === 0 && <option value="">（暂无 VIP 已登录）</option>}
+                  {vips.map((v) => (
+                    <option key={v.user_id} value={v.user_id}>
+                      {v.name}
+                      {v.title ? ` · ${v.title}` : ''}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={startQa}
+                  disabled={pending || !pendingHostId}
+                  className="w-full rounded-md bg-rose-500 px-2 py-1.5 text-xs font-medium text-white hover:bg-rose-400 disabled:opacity-50"
+                >
+                  开始 QA
+                </button>
+              </div>
+
+              <div className="space-y-1.5 border-t border-zinc-800 pt-2">
+                <label className="block text-[11px] text-zinc-400">抽奖 — 池子取在线 5 分钟内</label>
+                <label className="flex items-center gap-2 text-xs text-zinc-200">
+                  <input
+                    type="checkbox"
+                    checked={mustHavePosted}
+                    onChange={(e) => setMustHavePosted(e.target.checked)}
+                    className="size-3.5 rounded border-zinc-600 bg-zinc-800"
+                  />
+                  必须发过帖才能被抽
+                </label>
+                <label className="flex items-center gap-2 text-xs text-zinc-200">
+                  <input
+                    type="checkbox"
+                    checked={excludePreviousWinners}
+                    onChange={(e) => setExcludePreviousWinners(e.target.checked)}
+                    className="size-3.5 rounded border-zinc-600 bg-zinc-800"
+                  />
+                  排除上轮中奖者
+                </label>
+                <button
+                  type="button"
+                  onClick={startLottery}
+                  disabled={pending}
+                  className="w-full rounded-md bg-amber-500 px-2 py-1.5 text-xs font-medium text-white hover:bg-amber-400 disabled:opacity-50"
+                >
+                  开始抽奖
+                </button>
+              </div>
             </div>
           ) : (
             <button

--- a/src/components/screen/ScreenView.tsx
+++ b/src/components/screen/ScreenView.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { FeedPost } from '@/lib/queries/posts'
 import type { ScreenQuestion } from '@/lib/queries/questions'
+import type { ScreenLotteryDraw } from '@/lib/queries/lottery'
 import type { ScreenModeState } from '@/lib/queries/event-state'
 import { fetchScreenData } from '@/lib/actions/screen'
 import { getBrowserSupabase } from '@/lib/supabase/client'
@@ -45,6 +46,7 @@ export function ScreenView({
 }: Props) {
   const [posts, setPosts] = useState(initialPosts)
   const [questions, setQuestions] = useState<ScreenQuestion[]>([])
+  const [lottery, setLottery] = useState<ScreenLotteryDraw | null>(null)
   const [online, setOnline] = useState(initialOnline)
   const [mode, setMode] = useState<ScreenModeState>(initialMode)
   const [now, setNow] = useState(() => Date.now())
@@ -64,6 +66,7 @@ export function ScreenView({
         if (cancelled) return
         setPosts(snap.posts)
         setQuestions(snap.questions)
+        setLottery(snap.lottery)
         setOnline(snap.online)
         setMode(snap.mode)
       } catch {
@@ -115,14 +118,14 @@ export function ScreenView({
 
   // Slot dispatch:
   //   1. screen_mode='qa'      → QA layout (admin-controlled, top priority)
-  //   2. screen_mode='lottery' → Lottery layout (placeholder until #8)
+  //   2. screen_mode='lottery' → Lottery animation + winner
   //   3. active polls          → cycle [poll0 30s, poll1 30s, ..., default 30s]
   //   4. default               → DefaultSlot
   let slot: SlotState
   if (mode.mode === 'qa') {
     slot = { kind: 'qa' }
-  } else if (mode.mode === 'lottery') {
-    slot = { kind: 'default' } // TODO: replace with LotterySlot in task #8
+  } else if (mode.mode === 'lottery' && lottery) {
+    slot = { kind: 'lottery', draw: lottery }
   } else if (activePolls.length === 0) {
     slot = { kind: 'default' }
   } else {
@@ -146,6 +149,8 @@ export function ScreenView({
       <main className="mx-auto w-full max-w-[1600px] flex-1 overflow-hidden px-10 pb-6">
         {slot.kind === 'qa' ? (
           <QaSlot mode={mode} questions={questions} qrSlot={qrSlot} password={password} />
+        ) : slot.kind === 'lottery' ? (
+          <LotterySlot draw={slot.draw} now={now} />
         ) : slot.kind === 'poll' ? (
           <PollSlot post={slot.post} now={now} qrSlot={qrSlot} password={password} />
         ) : (
@@ -164,6 +169,7 @@ export function ScreenView({
 type SlotState =
   | { kind: 'default' }
   | { kind: 'qa' }
+  | { kind: 'lottery'; draw: ScreenLotteryDraw }
   | { kind: 'poll'; post: FeedPost }
 
 // Default slot: skeleton view shown when no poll is taking over.
@@ -327,6 +333,97 @@ function QrPanel({ qrSlot, password }: { qrSlot: React.ReactNode; password: stri
             {password}
           </p>
         </div>
+      )}
+    </div>
+  )
+}
+
+// Lottery animation: ~5s spin then settle on the (server-determined) winner.
+// Winner identity is fixed by the server; the animation is purely visual.
+const LOTTERY_SPIN_MS = 5_000
+
+function LotterySlot({ draw, now }: { draw: ScreenLotteryDraw; now: number }) {
+  // `now` ticks every 1s from the parent; we derive phase from it (pure render).
+  const startedAt = Date.parse(draw.created_at)
+  const phase: 'spinning' | 'settled' =
+    now - startedAt >= LOTTERY_SPIN_MS ? 'settled' : 'spinning'
+
+  // Faster cadence (80–500ms) is needed for the avatar swap during spin —
+  // 1s tick is too slow. Cell rotation lives in its own effect so it can
+  // schedule itself with a decelerating timer.
+  const [cellIdx, setCellIdx] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    function tick() {
+      if (cancelled) return
+      const elapsed = Date.now() - startedAt
+      if (elapsed >= LOTTERY_SPIN_MS) return
+      setCellIdx((i) => (i + 1) % Math.max(1, draw.pool_sample.length))
+      const t = Math.max(0, Math.min(1, elapsed / LOTTERY_SPIN_MS))
+      const interval = 80 + t * 420
+      timer = setTimeout(tick, interval)
+    }
+
+    if (Date.now() - startedAt < LOTTERY_SPIN_MS) {
+      timer = setTimeout(tick, 80)
+    }
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [draw.id, startedAt, draw.pool_sample.length])
+
+  const current =
+    phase === 'settled'
+      ? draw.winner
+      : draw.pool_sample[cellIdx % Math.max(1, draw.pool_sample.length)] ?? draw.winner
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-8">
+      <div className="inline-flex items-center gap-3 rounded-full bg-amber-500/20 px-5 py-2 ring-1 ring-amber-500/40">
+        <span className="text-base font-semibold text-amber-200">
+          {phase === 'spinning' ? '抽奖中…' : '🎉 中奖！'}
+        </span>
+        <span className="text-xs text-amber-300/80">池子 {draw.pool_sample.length}+ 人</span>
+      </div>
+
+      <div
+        className={
+          'rounded-3xl p-12 ring-2 transition-all duration-500 ' +
+          (phase === 'settled'
+            ? 'scale-110 bg-amber-500/20 ring-amber-400 shadow-[0_0_120px_rgba(251,191,36,0.5)]'
+            : 'bg-zinc-900/60 ring-zinc-700')
+        }
+      >
+        <div className="flex flex-col items-center gap-6">
+          <div className={phase === 'spinning' ? 'animate-pulse' : ''}>
+            <Avatar seed={current.id} user={current} size="3xl" onDark />
+          </div>
+          <div className="text-center">
+            <p className="text-6xl font-bold leading-tight text-white">{displayName(current)}</p>
+            {displayMeta(current) && (
+              <p className="mt-3 text-2xl text-zinc-300">{displayMeta(current)}</p>
+            )}
+            {current.is_vip && (
+              <p className="mt-3">
+                <span className="rounded-full bg-amber-500/30 px-3 py-1 text-base font-semibold text-amber-200">
+                  嘉宾
+                </span>
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {phase === 'settled' && (
+        <p className="text-lg text-zinc-400">
+          {draw.rules.must_have_posted && '已发帖 · '}
+          {draw.rules.exclude_previous_winners && '首次中奖'}
+        </p>
       )}
     </div>
   )

--- a/src/components/screen/ScreenView.tsx
+++ b/src/components/screen/ScreenView.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import type { FeedPost } from '@/lib/queries/posts'
+import type { ScreenQuestion } from '@/lib/queries/questions'
+import type { ScreenModeState } from '@/lib/queries/event-state'
 import { fetchScreenData } from '@/lib/actions/screen'
 import { getBrowserSupabase } from '@/lib/supabase/client'
 import { sectionLabel, SECTION_META, type SectionId } from '@/lib/sections'
@@ -19,6 +21,7 @@ const SLOT_MS = 30_000 // each poll slot
 type Props = {
   initialPosts: FeedPost[]
   initialOnline: number
+  initialMode: ScreenModeState
   eventName: string
   // 当前 URL 筛选板块；null 表示显示全部。
   section: SectionId | null
@@ -33,6 +36,7 @@ type Props = {
 export function ScreenView({
   initialPosts,
   initialOnline,
+  initialMode,
   eventName,
   section,
   liveSection,
@@ -40,7 +44,9 @@ export function ScreenView({
   qrSlot,
 }: Props) {
   const [posts, setPosts] = useState(initialPosts)
+  const [questions, setQuestions] = useState<ScreenQuestion[]>([])
   const [online, setOnline] = useState(initialOnline)
+  const [mode, setMode] = useState<ScreenModeState>(initialMode)
   const [now, setNow] = useState(() => Date.now())
 
   useEffect(() => {
@@ -57,7 +63,9 @@ export function ScreenView({
         const snap = await fetchScreenData(section)
         if (cancelled) return
         setPosts(snap.posts)
+        setQuestions(snap.questions)
         setOnline(snap.online)
+        setMode(snap.mode)
       } catch {
         // network blip — fallback interval will retry
       }
@@ -71,6 +79,10 @@ export function ScreenView({
       }, REALTIME_DEBOUNCE_MS)
     }
 
+    // First refresh after mount fills questions for the initial mode (server
+    // page already passes initialMode, but questions come from a separate fetch).
+    void refresh()
+
     const sb = getBrowserSupabase()
     const channel = sb
       .channel('screen-changes')
@@ -78,6 +90,7 @@ export function ScreenView({
       .on('postgres_changes', { event: '*', schema: 'public', table: 'replies' }, bump)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'likes' }, bump)
       .on('postgres_changes', { event: '*', schema: 'public', table: 'poll_votes' }, bump)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'event_state' }, bump)
       .subscribe()
 
     const fallback = setInterval(refresh, FALLBACK_REFRESH_MS)
@@ -100,17 +113,25 @@ export function ScreenView({
     [posts, now],
   )
 
-  // Slot dispatch: active polls cycle through takeover slots, then a
-  // 30s default skeleton slot, repeat. No active polls → always default.
-  // (QA / lottery modes will short-circuit this once screen_mode lands.)
-  const slot = activePolls.length === 0
-    ? { kind: 'default' as const }
-    : (() => {
-        const totalSlots = activePolls.length + 1
-        const idx = Math.floor(now / SLOT_MS) % totalSlots
-        if (idx === activePolls.length) return { kind: 'default' as const }
-        return { kind: 'poll' as const, post: activePolls[idx] }
-      })()
+  // Slot dispatch:
+  //   1. screen_mode='qa'      → QA layout (admin-controlled, top priority)
+  //   2. screen_mode='lottery' → Lottery layout (placeholder until #8)
+  //   3. active polls          → cycle [poll0 30s, poll1 30s, ..., default 30s]
+  //   4. default               → DefaultSlot
+  let slot: SlotState
+  if (mode.mode === 'qa') {
+    slot = { kind: 'qa' }
+  } else if (mode.mode === 'lottery') {
+    slot = { kind: 'default' } // TODO: replace with LotterySlot in task #8
+  } else if (activePolls.length === 0) {
+    slot = { kind: 'default' }
+  } else {
+    const totalSlots = activePolls.length + 1
+    const idx = Math.floor(now / SLOT_MS) % totalSlots
+    slot = idx === activePolls.length
+      ? { kind: 'default' }
+      : { kind: 'poll', post: activePolls[idx] }
+  }
 
   return (
     <div className="flex h-svh w-screen flex-col bg-zinc-950 text-zinc-100">
@@ -123,7 +144,9 @@ export function ScreenView({
       />
 
       <main className="mx-auto w-full max-w-[1600px] flex-1 overflow-hidden px-10 pb-6">
-        {slot.kind === 'poll' ? (
+        {slot.kind === 'qa' ? (
+          <QaSlot mode={mode} questions={questions} qrSlot={qrSlot} password={password} />
+        ) : slot.kind === 'poll' ? (
           <PollSlot post={slot.post} now={now} qrSlot={qrSlot} password={password} />
         ) : (
           <DefaultSlot
@@ -137,6 +160,11 @@ export function ScreenView({
     </div>
   )
 }
+
+type SlotState =
+  | { kind: 'default' }
+  | { kind: 'qa' }
+  | { kind: 'poll'; post: FeedPost }
 
 // Default slot: skeleton view shown when no poll is taking over.
 // Layout = giant QR (left) + LIVE 板块演讲信息 + 在线人数 (right).
@@ -300,6 +328,109 @@ function QrPanel({ qrSlot, password }: { qrSlot: React.ReactNode; password: stri
           </p>
         </div>
       )}
+    </div>
+  )
+}
+
+function QaSlot({
+  mode,
+  questions,
+  qrSlot,
+  password,
+}: {
+  mode: ScreenModeState
+  questions: ScreenQuestion[]
+  qrSlot: React.ReactNode
+  password: string
+}) {
+  const hostName = mode.qa_host_name ?? '嘉宾'
+  const top = questions.slice(0, 5)
+  const ticker = questions.slice(5, 13)
+
+  return (
+    <div className="grid h-full grid-cols-[1.1fr_1.4fr] gap-8">
+      {/* Left: 嘉宾 + QR */}
+      <div className="flex flex-col items-center justify-center gap-5 rounded-3xl bg-zinc-900/60 p-8 ring-1 ring-zinc-800">
+        <div className="inline-flex items-center gap-2 rounded-full bg-rose-500/20 px-4 py-1.5 ring-1 ring-rose-500/40">
+          <span className="relative flex size-2 shrink-0">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-rose-400 opacity-75" />
+            <span className="relative inline-flex size-2 rounded-full bg-rose-500" />
+          </span>
+          <span className="text-sm font-semibold text-rose-300">嘉宾 QA · 进行中</span>
+        </div>
+        <p className="text-center">
+          <span className="block text-5xl font-semibold leading-tight text-white">{hostName}</span>
+          {mode.qa_host_title && (
+            <span className="mt-2 block text-xl text-zinc-300">{mode.qa_host_title}</span>
+          )}
+        </p>
+        <div className="rounded-2xl bg-white p-4">{qrSlot}</div>
+        <p className="text-center text-2xl font-semibold text-white">扫码向 {hostName} 提问</p>
+        {password && (
+          <div className="w-full max-w-sm rounded-2xl bg-zinc-800/80 px-4 py-3 text-center ring-1 ring-zinc-700">
+            <p className="text-[11px] uppercase tracking-[0.18em] text-zinc-400">扫不动？手输密码</p>
+            <p className="mt-1 select-all font-mono text-2xl font-semibold tracking-[0.2em] text-white">
+              {password}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Right: 问题列表 */}
+      <div className="flex h-full min-h-0 flex-col gap-4">
+        <p className="text-sm uppercase tracking-[0.18em] text-zinc-500">
+          观众提问 · 共 {questions.length} 条 · 按点赞排序
+        </p>
+        {questions.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center rounded-2xl bg-zinc-900/40 ring-1 ring-zinc-800/60">
+            <p className="text-2xl text-zinc-500">还没有人提问，扫码抢沙发 →</p>
+          </div>
+        ) : (
+          <>
+            <ul className="flex flex-1 min-h-0 flex-col gap-3 overflow-hidden">
+              {top.map((q, i) => (
+                <li
+                  key={q.id}
+                  className="flex gap-4 rounded-2xl bg-zinc-900 px-6 py-4 ring-1 ring-zinc-800"
+                >
+                  <span className="shrink-0 text-3xl font-bold tabular-nums text-zinc-600">
+                    {i + 1}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="whitespace-pre-wrap text-2xl leading-snug text-white">
+                      {q.body}
+                    </p>
+                    <p className="mt-2 flex items-center gap-3 text-sm text-zinc-400">
+                      <span>{displayName(q.author)}</span>
+                      {displayMeta(q.author) && (
+                        <span className="text-zinc-500">· {displayMeta(q.author)}</span>
+                      )}
+                      <span className="ml-auto font-semibold text-rose-300">
+                        ❤ {q.like_count}
+                      </span>
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+            {ticker.length > 0 && (
+              <div className="rounded-2xl bg-zinc-900/40 px-5 py-3 ring-1 ring-zinc-800/60">
+                <p className="mb-2 text-[11px] uppercase tracking-[0.18em] text-zinc-500">
+                  排队中
+                </p>
+                <ul className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm text-zinc-300">
+                  {ticker.map((q) => (
+                    <li key={q.id} className="flex items-center gap-2 truncate">
+                      <span className="shrink-0 text-xs text-rose-400">❤{q.like_count}</span>
+                      <span className="truncate">{q.body}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/screen/ScreenView.tsx
+++ b/src/components/screen/ScreenView.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { ArrowDown } from 'lucide-react'
 import type { FeedPost } from '@/lib/queries/posts'
 import { fetchScreenData } from '@/lib/actions/screen'
 import { getBrowserSupabase } from '@/lib/supabase/client'
@@ -15,8 +14,7 @@ const POLL_TICK_MS = 1_000 // ui re-render cadence
 // unattended for hours. Realtime events are the primary trigger.
 const FALLBACK_REFRESH_MS = 60_000
 const REALTIME_DEBOUNCE_MS = 500
-const SLOT_MS = 30_000 // each poll/timeline slot
-const TIMELINE_FOCUS_MS = 8_000 // each timeline post highlight duration
+const SLOT_MS = 30_000 // each poll slot
 
 type Props = {
   initialPosts: FeedPost[]
@@ -102,14 +100,15 @@ export function ScreenView({
     [posts, now],
   )
 
-  // Cycle: [poll0 30s, poll1 30s, ..., timeline 30s], repeat.
-  // If no active polls → always timeline.
+  // Slot dispatch: active polls cycle through takeover slots, then a
+  // 30s default skeleton slot, repeat. No active polls → always default.
+  // (QA / lottery modes will short-circuit this once screen_mode lands.)
   const slot = activePolls.length === 0
-    ? { kind: 'timeline' as const }
+    ? { kind: 'default' as const }
     : (() => {
         const totalSlots = activePolls.length + 1
         const idx = Math.floor(now / SLOT_MS) % totalSlots
-        if (idx === activePolls.length) return { kind: 'timeline' as const }
+        if (idx === activePolls.length) return { kind: 'default' as const }
         return { kind: 'poll' as const, post: activePolls[idx] }
       })()
 
@@ -127,101 +126,86 @@ export function ScreenView({
         {slot.kind === 'poll' ? (
           <PollSlot post={slot.post} now={now} qrSlot={qrSlot} password={password} />
         ) : (
-          <TimelineSlot posts={posts} now={now} qrSlot={qrSlot} password={password} />
+          <DefaultSlot
+            liveSection={liveSection}
+            online={online}
+            qrSlot={qrSlot}
+            password={password}
+          />
         )}
       </main>
     </div>
   )
 }
 
-function TimelineSlot({
-  posts,
-  now,
+// Default slot: skeleton view shown when no poll is taking over.
+// Layout = giant QR (left) + LIVE 板块演讲信息 + 在线人数 (right).
+// 不再轮播热帖 — 主位留给当下正在发生的事（投票 / QA / 抽奖）。
+function DefaultSlot({
+  liveSection,
+  online,
   qrSlot,
   password,
 }: {
-  posts: FeedPost[]
-  now: number
+  liveSection: SectionId | null
+  online: number
   qrSlot: React.ReactNode
   password: string
 }) {
-  // Use only text posts for the focus rotation; polls already get takeover slots.
-  const textPosts = posts.filter((p) => p.type === 'text').slice(0, 12)
-  if (textPosts.length === 0) {
-    return (
-      <div className="grid h-full grid-cols-[1.6fr_1fr] gap-6">
-        <div className="flex items-center justify-center rounded-2xl bg-zinc-900/40 ring-1 ring-zinc-800/60 text-zinc-500">
-          <p className="flex items-center gap-2 text-2xl">
-            还没有人发帖。扫码加入聊起来
-            <ArrowDown className="size-6" aria-hidden />
-          </p>
-        </div>
-        <QrPanel qrSlot={qrSlot} password={password} />
-      </div>
-    )
-  }
-  const focusIdx = Math.floor(now / TIMELINE_FOCUS_MS) % textPosts.length
-  const focus = textPosts[focusIdx]
-  const upNext = textPosts.filter((_, i) => i !== focusIdx).slice(0, 4)
-
+  const liveMeta = liveSection ? SECTION_META[liveSection] : null
   return (
-    <div className="grid h-full grid-rows-[1fr_auto] gap-5">
-      <div className="grid min-h-0 grid-cols-[1.6fr_1fr] gap-6">
-        <article className="overflow-hidden rounded-2xl bg-zinc-900 px-10 py-8 ring-1 ring-zinc-800">
-          <PostHeader post={focus} large />
-          <p className="mt-4 whitespace-pre-wrap text-3xl leading-snug text-white">
-            {focus.body}
-          </p>
-          {focus.tags.length > 0 && (
-            <div className="mt-4 flex flex-wrap gap-2">
-              {focus.tags.map((t) => (
-                <span
-                  key={t}
-                  className="rounded-full bg-zinc-800 px-3 py-1 text-base text-zinc-300"
-                >
-                  #{t}
-                </span>
-              ))}
+    <div className="grid h-full grid-cols-[1fr_1fr] items-stretch gap-8">
+      <div className="flex flex-col items-center justify-center gap-6 rounded-3xl bg-zinc-900/50 p-8 ring-1 ring-zinc-800">
+        <div className="rounded-2xl bg-white p-5">{qrSlot}</div>
+        <div className="text-center leading-tight">
+          <p className="text-3xl font-semibold text-white">扫码一键加入</p>
+          <p className="mt-1 text-base text-zinc-400">发帖 · 投票 · 找人</p>
+        </div>
+        {password && (
+          <div className="w-full max-w-md rounded-2xl bg-zinc-800/80 px-6 py-4 text-center ring-1 ring-zinc-700">
+            <p className="text-xs uppercase tracking-[0.2em] text-zinc-400">扫不动？手输密码</p>
+            <p className="mt-1.5 select-all font-mono text-4xl font-semibold tracking-[0.18em] text-white">
+              {password}
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col justify-center gap-8 rounded-3xl bg-zinc-900/30 p-10 ring-1 ring-zinc-800/60">
+        {liveSection && liveMeta ? (
+          <div>
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-rose-500/20 px-3 py-1 ring-1 ring-rose-500/40">
+              <span className="relative flex size-2 shrink-0">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-rose-400 opacity-75" />
+                <span className="relative inline-flex size-2 rounded-full bg-rose-500" />
+              </span>
+              <span className="text-sm font-semibold text-rose-300">现在 LIVE</span>
+              <span className="text-sm text-zinc-200">{sectionLabel(liveSection)}</span>
             </div>
-          )}
-        </article>
-        <QrPanel qrSlot={qrSlot} password={password} />
-      </div>
-      {upNext.length > 0 && (
-        <div className="grid grid-cols-4 gap-3">
-          {upNext.map((p) => (
-            <article
-              key={p.id}
-              className="overflow-hidden rounded-xl bg-zinc-900/60 px-5 py-4 ring-1 ring-zinc-800"
-            >
-              <PostHeader post={p} />
-              <p className="mt-1 line-clamp-3 whitespace-pre-wrap text-base text-zinc-200">
-                {p.body}
+            <p className="text-4xl font-semibold leading-tight text-white">
+              {liveMeta.topic}
+            </p>
+            {liveMeta.speaker && (
+              <p className="mt-3 text-2xl text-zinc-200">
+                {liveMeta.speaker}
+                {liveMeta.affiliation && (
+                  <span className="ml-2 text-xl text-zinc-400">· {liveMeta.affiliation}</span>
+                )}
               </p>
-            </article>
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
+            )}
+          </div>
+        ) : (
+          <div>
+            <p className="text-3xl font-semibold text-zinc-300">空档期</p>
+            <p className="mt-2 text-lg text-zinc-500">下一个板块即将开始</p>
+          </div>
+        )}
 
-function QrPanel({ qrSlot, password }: { qrSlot: React.ReactNode; password: string }) {
-  return (
-    <div className="flex flex-col items-center justify-center gap-4 rounded-2xl bg-zinc-900/60 px-8 py-6 ring-1 ring-zinc-800">
-      <div className="rounded-xl bg-white p-3">{qrSlot}</div>
-      <p className="text-center leading-tight">
-        <span className="block text-xl font-semibold text-white">扫码一键加入</span>
-        <span className="text-sm text-zinc-400">发帖 / 投票 / 找人</span>
-      </p>
-      {password && (
-        <div className="w-full rounded-xl bg-zinc-800/80 px-4 py-3 text-center ring-1 ring-zinc-700">
-          <p className="text-xs uppercase tracking-[0.18em] text-zinc-400">扫不动？手输密码</p>
-          <p className="mt-1 select-all font-mono text-3xl font-semibold tracking-wider text-white">
-            {password}
-          </p>
+        <div className="rounded-2xl bg-zinc-900/60 px-6 py-5 ring-1 ring-zinc-800">
+          <p className="text-sm uppercase tracking-[0.18em] text-zinc-500">在线人数</p>
+          <p className="mt-1 text-6xl font-semibold tabular-nums text-white">{online}</p>
         </div>
-      )}
+      </div>
     </div>
   )
 }
@@ -253,7 +237,7 @@ function PollSlot({
           <span className="rounded-full bg-indigo-500 px-3 py-1 text-sm font-semibold text-white">
             投票进行中
           </span>
-          <PostHeader post={post} compact />
+          <PostHeader post={post} />
         </div>
         <p className="whitespace-pre-wrap text-4xl font-semibold leading-tight text-white">
           {post.body}
@@ -300,26 +284,35 @@ function PollSlot({
   )
 }
 
-function PostHeader({
-  post,
-  large,
-  compact,
-}: {
-  post: FeedPost
-  large?: boolean
-  compact?: boolean
-}) {
+function QrPanel({ qrSlot, password }: { qrSlot: React.ReactNode; password: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 rounded-2xl bg-zinc-900/60 px-8 py-6 ring-1 ring-zinc-800">
+      <div className="rounded-xl bg-white p-3">{qrSlot}</div>
+      <p className="text-center leading-tight">
+        <span className="block text-xl font-semibold text-white">扫码一键加入</span>
+        <span className="text-sm text-zinc-400">发帖 / 投票 / 找人</span>
+      </p>
+      {password && (
+        <div className="w-full rounded-xl bg-zinc-800/80 px-4 py-3 text-center ring-1 ring-zinc-700">
+          <p className="text-xs uppercase tracking-[0.18em] text-zinc-400">扫不动？手输密码</p>
+          <p className="mt-1 select-all font-mono text-3xl font-semibold tracking-wider text-white">
+            {password}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function PostHeader({ post }: { post: FeedPost }) {
   const a = post.author
   const name = displayName(a)
   const meta = displayMeta(a)
-  const sizeName = large ? 'text-2xl' : compact ? 'text-base' : 'text-xl'
-  const sizeMeta = large ? 'text-lg' : 'text-sm'
-  const avatarSize = large ? 'lg' : compact ? 'sm' : 'md'
   return (
     <div className="flex items-center gap-3">
-      <Avatar seed={post.user_id} user={a} size={avatarSize} onDark />
-      <span className={`${sizeName} font-semibold text-white`}>{name}</span>
-      {meta && <span className={`${sizeMeta} text-zinc-400`}>· {meta}</span>}
+      <Avatar seed={post.user_id} user={a} size="sm" onDark />
+      <span className="text-base font-semibold text-white">{name}</span>
+      {meta && <span className="text-sm text-zinc-400">· {meta}</span>}
       {a.is_vip && (
         <span className="rounded-full bg-amber-500/20 px-2 py-0.5 text-xs font-medium text-amber-300">
           嘉宾

--- a/src/lib/actions/event-state.ts
+++ b/src/lib/actions/event-state.ts
@@ -49,3 +49,60 @@ export async function clearCurrentSectionAction(): Promise<{ error: string | nul
   revalidatePath('/feed')
   return { error: null }
 }
+
+// =====================================================================
+// screen_mode (issue #27) — admin 控制 QA / lottery / default
+// =====================================================================
+
+// 进入 QA 模式：指定一个 VIP 作为被提问的嘉宾。
+export async function startQaAction(
+  hostUserId: string,
+): Promise<{ error: string | null }> {
+  if (!(await readAdminCookie())) return { error: '未授权' }
+  if (!hostUserId) return { error: '请先选择嘉宾' }
+
+  const sb = getServerSupabase()
+
+  // 校验该 user 确实是 VIP（防止误传普通 user 进 QA host 字段）
+  const { data: host, error: hostErr } = await sb
+    .from('users')
+    .select('id, is_vip')
+    .eq('id', hostUserId)
+    .maybeSingle()
+  if (hostErr) return { error: hostErr.message }
+  if (!host || !host.is_vip) return { error: '该用户不是嘉宾' }
+
+  const { error } = await sb
+    .from('event_state')
+    .update({
+      screen_mode: 'qa',
+      qa_host_user_id: hostUserId,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', 1)
+
+  if (error) return { error: error.message }
+  revalidatePath('/screen')
+  revalidatePath('/feed')
+  return { error: null }
+}
+
+// 退出 QA / lottery，回到 default 骨架。
+export async function exitScreenModeAction(): Promise<{ error: string | null }> {
+  if (!(await readAdminCookie())) return { error: '未授权' }
+
+  const sb = getServerSupabase()
+  const { error } = await sb
+    .from('event_state')
+    .update({
+      screen_mode: 'default',
+      qa_host_user_id: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', 1)
+
+  if (error) return { error: error.message }
+  revalidatePath('/screen')
+  revalidatePath('/feed')
+  return { error: null }
+}

--- a/src/lib/actions/event-state.ts
+++ b/src/lib/actions/event-state.ts
@@ -77,6 +77,7 @@ export async function startQaAction(
     .update({
       screen_mode: 'qa',
       qa_host_user_id: hostUserId,
+      lottery_draw_id: null,
       updated_at: new Date().toISOString(),
     })
     .eq('id', 1)

--- a/src/lib/actions/event-state.ts
+++ b/src/lib/actions/event-state.ts
@@ -97,6 +97,7 @@ export async function exitScreenModeAction(): Promise<{ error: string | null }> 
     .update({
       screen_mode: 'default',
       qa_host_user_id: null,
+      lottery_draw_id: null,
       updated_at: new Date().toISOString(),
     })
     .eq('id', 1)
@@ -104,5 +105,88 @@ export async function exitScreenModeAction(): Promise<{ error: string | null }> 
   if (error) return { error: error.message }
   revalidatePath('/screen')
   revalidatePath('/feed')
+  return { error: null }
+}
+
+// =====================================================================
+// 抽奖 (issue #27)
+// =====================================================================
+const ONLINE_WINDOW_MS = 5 * 60 * 1000
+
+export type LotteryRulesInput = {
+  must_have_posted?: boolean
+  exclude_previous_winners?: boolean
+}
+
+// 开始一轮抽奖。winner 在服务端选好（防作弊）；前端只播动画。
+export async function startLotteryAction(
+  rulesIn: LotteryRulesInput,
+): Promise<{ error: string | null }> {
+  if (!(await readAdminCookie())) return { error: '未授权' }
+
+  const rules = {
+    must_have_posted: !!rulesIn.must_have_posted,
+    exclude_previous_winners: rulesIn.exclude_previous_winners ?? true,
+  }
+
+  const sb = getServerSupabase()
+  const cutoff = new Date(Date.now() - ONLINE_WINDOW_MS).toISOString()
+
+  // 1. 在线用户（last_seen_at 5min 内）
+  const { data: onlineUsers, error: onlineErr } = await sb
+    .from('users')
+    .select('id')
+    .gte('last_seen_at', cutoff)
+  if (onlineErr) return { error: onlineErr.message }
+  let pool = (onlineUsers ?? []).map((u) => u.id as string)
+  if (pool.length === 0) return { error: '当前没有在线参与者' }
+
+  // 2. must_have_posted: 至少发过一帖（任何 type）
+  if (rules.must_have_posted) {
+    const { data: posters } = await sb
+      .from('posts')
+      .select('user_id')
+      .in('user_id', pool)
+    const posterSet = new Set((posters ?? []).map((p) => p.user_id as string))
+    pool = pool.filter((id) => posterSet.has(id))
+    if (pool.length === 0) return { error: '没有满足「必须发过帖」的在线参与者' }
+  }
+
+  // 3. exclude_previous_winners: 历次中奖人都剔除
+  if (rules.exclude_previous_winners) {
+    const { data: prev } = await sb.from('lottery_draws').select('winner_user_id')
+    const winnerSet = new Set((prev ?? []).map((p) => p.winner_user_id as string))
+    pool = pool.filter((id) => !winnerSet.has(id))
+    if (pool.length === 0) return { error: '所有满足条件的人都中过奖了，换个规则？' }
+  }
+
+  // 4. 随机选 winner
+  const winner = pool[Math.floor(Math.random() * pool.length)]
+
+  // 5. 写 lottery_draws
+  const { data: draw, error: drawErr } = await sb
+    .from('lottery_draws')
+    .insert({
+      rules,
+      pool_user_ids: pool,
+      winner_user_id: winner,
+    })
+    .select('id')
+    .single()
+  if (drawErr) return { error: drawErr.message }
+
+  // 6. 切 event_state；先清 qa_host 防止 mode_consistency 约束失败
+  const { error: stateErr } = await sb
+    .from('event_state')
+    .update({
+      screen_mode: 'lottery',
+      qa_host_user_id: null,
+      lottery_draw_id: draw.id,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', 1)
+  if (stateErr) return { error: stateErr.message }
+
+  revalidatePath('/screen')
   return { error: null }
 }

--- a/src/lib/actions/posts.ts
+++ b/src/lib/actions/posts.ts
@@ -119,6 +119,59 @@ export async function updatePostAction(
   return { error: null }
 }
 
+// 观众端 QA 提问 — 比 createPostAction 简洁很多：没有 tags / section / match_intent。
+// hostUserId 必须当下确实是 event_state.qa_host_user_id；防止活动结束后还能注水。
+export async function createQuestionAction(
+  _prev: PostFormState,
+  formData: FormData,
+): Promise<PostFormState> {
+  const user = await getCurrentUser()
+  if (!user) redirect('/')
+
+  const body = String(formData.get('body') ?? '').trim()
+  if (!body) return { error: '说点啥再发吧' }
+  if (body.length > POST_MAX_CHARS) return { error: `不能超过 ${POST_MAX_CHARS} 字` }
+
+  const sb = getServerSupabase()
+
+  const { data: state, error: stateErr } = await sb
+    .from('event_state')
+    .select('screen_mode, qa_host_user_id')
+    .eq('id', 1)
+    .maybeSingle()
+  if (stateErr) return { error: stateErr.message }
+  if (!state || state.screen_mode !== 'qa' || !state.qa_host_user_id) {
+    return { error: 'QA 已经结束了' }
+  }
+
+  // Identity updates: nickname / company optional; questions are usually
+  // posted with whatever identity the user has. Match createPostAction's
+  // pattern so users can edit-and-submit in one go.
+  const nickname = nullableStr(formData.get('nickname'))
+  const company = nullableStr(formData.get('company'))
+  const contactHandle = nullableStr(formData.get('contact_handle'))
+  const updates: Record<string, unknown> = { last_seen_at: new Date().toISOString() }
+  if (nickname !== undefined) updates.nickname = nickname
+  if (company !== undefined) updates.company = company
+  if (contactHandle !== undefined) updates.contact_handle = contactHandle
+  await sb.from('users').update(updates).eq('id', user.id)
+
+  const { error } = await sb.from('posts').insert({
+    user_id: user.id,
+    type: 'question',
+    body,
+    tags: [],
+    show_contact: false,
+    section: null,
+    question_target_user_id: state.qa_host_user_id,
+  })
+  if (error) return { error: error.message }
+
+  revalidatePath('/feed')
+  revalidatePath('/screen')
+  return { error: null, ok: true }
+}
+
 export async function deletePostAction(postId: number): Promise<PostMutationResult> {
   const user = await getCurrentUser()
   if (!user) redirect('/')

--- a/src/lib/actions/screen.ts
+++ b/src/lib/actions/screen.ts
@@ -3,6 +3,7 @@
 import { getServerSupabase } from '@/lib/supabase/server'
 import { fetchFeed, type FeedPost } from '@/lib/queries/posts'
 import { fetchQuestionsForHost, type ScreenQuestion } from '@/lib/queries/questions'
+import { fetchLotteryDraw, type ScreenLotteryDraw } from '@/lib/queries/lottery'
 import { getScreenModeState, type ScreenModeState } from '@/lib/queries/event-state'
 import { isSectionId, type SectionId } from '@/lib/sections'
 
@@ -14,6 +15,7 @@ const ONLINE_WINDOW_MS = 5 * 60 * 1000
 export type ScreenSnapshot = {
   posts: FeedPost[]
   questions: ScreenQuestion[]
+  lottery: ScreenLotteryDraw | null
   online: number
   mode: ScreenModeState
   serverNow: number
@@ -32,13 +34,19 @@ export async function fetchScreenData(section?: string | null): Promise<ScreenSn
     getScreenModeState(),
   ])
 
-  const questions = mode.mode === 'qa' && mode.qa_host_user_id
-    ? await fetchQuestionsForHost(mode.qa_host_user_id)
-    : []
+  const [questions, lottery] = await Promise.all([
+    mode.mode === 'qa' && mode.qa_host_user_id
+      ? fetchQuestionsForHost(mode.qa_host_user_id)
+      : Promise.resolve([] as ScreenQuestion[]),
+    mode.mode === 'lottery' && mode.lottery_draw_id
+      ? fetchLotteryDraw(mode.lottery_draw_id)
+      : Promise.resolve(null as ScreenLotteryDraw | null),
+  ])
 
   return {
     posts,
     questions,
+    lottery,
     online: onlineRes.count ?? 0,
     mode,
     serverNow: Date.now(),

--- a/src/lib/actions/screen.ts
+++ b/src/lib/actions/screen.ts
@@ -2,6 +2,8 @@
 
 import { getServerSupabase } from '@/lib/supabase/server'
 import { fetchFeed, type FeedPost } from '@/lib/queries/posts'
+import { fetchQuestionsForHost, type ScreenQuestion } from '@/lib/queries/questions'
+import { getScreenModeState, type ScreenModeState } from '@/lib/queries/event-state'
 import { isSectionId, type SectionId } from '@/lib/sections'
 
 // The screen has no viewer identity — using a zero UUID makes liked_by_me /
@@ -11,7 +13,9 @@ const ONLINE_WINDOW_MS = 5 * 60 * 1000
 
 export type ScreenSnapshot = {
   posts: FeedPost[]
+  questions: ScreenQuestion[]
   online: number
+  mode: ScreenModeState
   serverNow: number
 }
 
@@ -19,16 +23,24 @@ export async function fetchScreenData(section?: string | null): Promise<ScreenSn
   const sb = getServerSupabase()
   const cutoff = new Date(Date.now() - ONLINE_WINDOW_MS).toISOString()
   const sectionFilter: SectionId | undefined = isSectionId(section) ? section : undefined
-  const [posts, onlineRes] = await Promise.all([
+  const [posts, onlineRes, mode] = await Promise.all([
     fetchFeed(SCREEN_VIEWER_ID, { limit: 50, section: sectionFilter }),
     sb
       .from('users')
       .select('id', { count: 'exact', head: true })
       .gte('last_seen_at', cutoff),
+    getScreenModeState(),
   ])
+
+  const questions = mode.mode === 'qa' && mode.qa_host_user_id
+    ? await fetchQuestionsForHost(mode.qa_host_user_id)
+    : []
+
   return {
     posts,
+    questions,
     online: onlineRes.count ?? 0,
+    mode,
     serverNow: Date.now(),
   }
 }

--- a/src/lib/queries/event-state.ts
+++ b/src/lib/queries/event-state.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 import { getServerSupabase } from '@/lib/supabase/server'
 import { isSectionId, sectionByClock, type SectionId } from '@/lib/sections'
+import type { ScreenMode } from '@/lib/types'
 
 // 主办方覆写优先；过期或未设置则回落到议程时间表 (sectionByClock)。
 // 不命中（空档期 / 活动开始前 / 结束后）返回 null。
@@ -21,4 +22,67 @@ export async function getCurrentSection(): Promise<SectionId | null> {
   }
 
   return sectionByClock()
+}
+
+export type ScreenModeState = {
+  mode: ScreenMode
+  qa_host_user_id: string | null
+  qa_host_name: string | null
+  qa_host_title: string | null
+}
+
+// 读 screen_mode + 可能伴随的 host 信息。一次查询即够 — /screen 顶层 fetch。
+export async function getScreenModeState(): Promise<ScreenModeState> {
+  const sb = getServerSupabase()
+  const { data } = await sb
+    .from('event_state')
+    .select(
+      'screen_mode, qa_host_user_id, host:users!qa_host_user_id ( vip_name, nickname, vip_title, company )',
+    )
+    .eq('id', 1)
+    .maybeSingle()
+
+  if (!data) {
+    return { mode: 'default', qa_host_user_id: null, qa_host_name: null, qa_host_title: null }
+  }
+
+  type HostRow = {
+    vip_name: string | null
+    nickname: string | null
+    vip_title: string | null
+    company: string | null
+  }
+  const hostRel = (data as { host?: HostRow | HostRow[] | null }).host
+  const host = Array.isArray(hostRel) ? hostRel[0] ?? null : hostRel ?? null
+
+  const mode = (data.screen_mode as ScreenMode) ?? 'default'
+  return {
+    mode,
+    qa_host_user_id: (data.qa_host_user_id as string | null) ?? null,
+    qa_host_name: host ? host.vip_name ?? host.nickname ?? null : null,
+    qa_host_title: host ? host.vip_title ?? host.company ?? null : null,
+  }
+}
+
+export type VipForDropdown = {
+  user_id: string
+  name: string
+  title: string | null
+}
+
+// 给 admin 控制台 QA host dropdown 用：列出已绑定的 VIP（vip_tokens.user_id 非空）。
+export async function listVipUsers(): Promise<VipForDropdown[]> {
+  const sb = getServerSupabase()
+  const { data, error } = await sb
+    .from('vip_tokens')
+    .select('user_id, vip_name, vip_title')
+    .not('user_id', 'is', null)
+    .order('vip_name')
+
+  if (error || !data) return []
+  return data
+    .filter((r): r is { user_id: string; vip_name: string; vip_title: string | null } =>
+      typeof r.user_id === 'string',
+    )
+    .map((r) => ({ user_id: r.user_id, name: r.vip_name, title: r.vip_title }))
 }

--- a/src/lib/queries/event-state.ts
+++ b/src/lib/queries/event-state.ts
@@ -29,6 +29,7 @@ export type ScreenModeState = {
   qa_host_user_id: string | null
   qa_host_name: string | null
   qa_host_title: string | null
+  lottery_draw_id: number | null
 }
 
 // 读 screen_mode + 可能伴随的 host 信息。一次查询即够 — /screen 顶层 fetch。
@@ -37,13 +38,19 @@ export async function getScreenModeState(): Promise<ScreenModeState> {
   const { data } = await sb
     .from('event_state')
     .select(
-      'screen_mode, qa_host_user_id, host:users!qa_host_user_id ( vip_name, nickname, vip_title, company )',
+      'screen_mode, qa_host_user_id, lottery_draw_id, host:users!qa_host_user_id ( vip_name, nickname, vip_title, company )',
     )
     .eq('id', 1)
     .maybeSingle()
 
   if (!data) {
-    return { mode: 'default', qa_host_user_id: null, qa_host_name: null, qa_host_title: null }
+    return {
+      mode: 'default',
+      qa_host_user_id: null,
+      qa_host_name: null,
+      qa_host_title: null,
+      lottery_draw_id: null,
+    }
   }
 
   type HostRow = {
@@ -61,6 +68,7 @@ export async function getScreenModeState(): Promise<ScreenModeState> {
     qa_host_user_id: (data.qa_host_user_id as string | null) ?? null,
     qa_host_name: host ? host.vip_name ?? host.nickname ?? null : null,
     qa_host_title: host ? host.vip_title ?? host.company ?? null : null,
+    lottery_draw_id: (data.lottery_draw_id as number | null) ?? null,
   }
 }
 

--- a/src/lib/queries/lottery.ts
+++ b/src/lib/queries/lottery.ts
@@ -1,0 +1,88 @@
+import 'server-only'
+import { getServerSupabase } from '@/lib/supabase/server'
+import type { LotteryRules, PublicUserDisplay } from '@/lib/types'
+
+type LotteryUserMini = Pick<
+  PublicUserDisplay,
+  'id' | 'nickname' | 'company' | 'is_vip' | 'vip_name' | 'vip_title'
+>
+
+export type ScreenLotteryDraw = {
+  id: number
+  rules: LotteryRules
+  winner: LotteryUserMini
+  // 动画用的候选池采样（最多 30 个 user，前端动画卡格够用）。
+  // 已经包含 winner，前端不需要单独保证。
+  pool_sample: LotteryUserMini[]
+  created_at: string
+}
+
+const POOL_SAMPLE_SIZE = 30
+
+// /screen 在 mode='lottery' 时调用。把抽奖行 + 中奖人 + 一组动画用 user
+// profile 一起拿出来。失败返回 null（/screen 会回落到 default）。
+export async function fetchLotteryDraw(
+  drawId: number,
+): Promise<ScreenLotteryDraw | null> {
+  const sb = getServerSupabase()
+
+  const { data: draw, error: drawErr } = await sb
+    .from('lottery_draws')
+    .select('id, rules, pool_user_ids, winner_user_id, created_at')
+    .eq('id', drawId)
+    .maybeSingle()
+  if (drawErr || !draw) return null
+
+  const pool = (draw.pool_user_ids as string[]) ?? []
+  const winnerId = draw.winner_user_id as string
+
+  // Sample up to N from pool, ensure winner is included
+  const sampleIds = sampleWithGuarantee(pool, POOL_SAMPLE_SIZE, winnerId)
+
+  const { data: users, error: usersErr } = await sb
+    .from('users')
+    .select('id, nickname, company, is_vip, vip_name, vip_title')
+    .in('id', sampleIds)
+  if (usersErr || !users) return null
+
+  const byId = new Map<string, LotteryUserMini>()
+  for (const u of users) {
+    byId.set(u.id as string, u as LotteryUserMini)
+  }
+
+  const winner = byId.get(winnerId)
+  if (!winner) return null
+
+  const pool_sample = sampleIds
+    .map((id) => byId.get(id))
+    .filter((u): u is LotteryUserMini => Boolean(u))
+
+  return {
+    id: draw.id as number,
+    rules: (draw.rules as LotteryRules) ?? {
+      must_have_posted: false,
+      exclude_previous_winners: true,
+    },
+    winner,
+    pool_sample,
+    created_at: draw.created_at as string,
+  }
+}
+
+function sampleWithGuarantee(arr: string[], n: number, mustInclude: string): string[] {
+  if (arr.length <= n) {
+    return Array.from(new Set(arr.concat([mustInclude])))
+  }
+  // Fisher-Yates partial shuffle
+  const a = arr.slice()
+  for (let i = a.length - 1; i > a.length - 1 - n; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  const sampled = a.slice(a.length - n)
+  if (!sampled.includes(mustInclude)) {
+    // Replace one slot with the winner so animation always has a chance to land on them
+    sampled[0] = mustInclude
+  }
+  return Array.from(new Set(sampled))
+}

--- a/src/lib/queries/posts.ts
+++ b/src/lib/queries/posts.ts
@@ -59,6 +59,7 @@ export async function fetchFeed(
     .select(
       `id, user_id, type, body, tags, show_contact, section,
        poll_options, poll_multi, poll_deadline, poll_hide_results,
+       question_target_user_id,
        created_at,
        author:users!user_id ( nickname, company, contact_handle, show_contact, is_vip, vip_name, vip_title ),
        replies (

--- a/src/lib/queries/questions.ts
+++ b/src/lib/queries/questions.ts
@@ -1,0 +1,72 @@
+import 'server-only'
+import { getServerSupabase } from '@/lib/supabase/server'
+import type { PublicUserDisplay } from '@/lib/types'
+
+type QuestionAuthor = Pick<
+  PublicUserDisplay,
+  'nickname' | 'company' | 'is_vip' | 'vip_name' | 'vip_title'
+>
+
+export type ScreenQuestion = {
+  id: number
+  user_id: string
+  body: string
+  created_at: string
+  like_count: number
+  author: QuestionAuthor
+}
+
+// 给 /screen QA 模式使用：拉所有提问给该 host 的 question post，按 like 降序、
+// 同 like 时按时间降序。limit 13（顶 5 大字号 + 8 ticker）。
+export async function fetchQuestionsForHost(
+  hostUserId: string,
+  limit = 13,
+): Promise<ScreenQuestion[]> {
+  const sb = getServerSupabase()
+
+  // 一次拿 question posts + 各帖 like 计数。Supabase 不支持 group-by aggregate 直接
+  // 选最高，所以分两次：先拿 posts（按时间倒序限 100 防爆），再聚合 likes。
+  const [postsRes, likesRes] = await Promise.all([
+    sb
+      .from('posts')
+      .select(
+        `id, user_id, body, created_at,
+         author:users!user_id ( nickname, company, is_vip, vip_name, vip_title )`,
+      )
+      .eq('type', 'question')
+      .eq('question_target_user_id', hostUserId)
+      .order('created_at', { ascending: false })
+      .limit(100),
+    sb.from('likes').select('post_id'),
+  ])
+
+  if (postsRes.error || !postsRes.data) {
+    if (postsRes.error) console.error('fetchQuestionsForHost posts error:', postsRes.error)
+    return []
+  }
+
+  const likeCounts = new Map<number, number>()
+  for (const l of likesRes.data ?? []) {
+    const pid = l.post_id as number
+    likeCounts.set(pid, (likeCounts.get(pid) ?? 0) + 1)
+  }
+
+  const items: ScreenQuestion[] = postsRes.data.map((row) => {
+    const a = row.author as QuestionAuthor | QuestionAuthor[] | null
+    const author = Array.isArray(a) ? a[0] : (a as QuestionAuthor)
+    return {
+      id: row.id as number,
+      user_id: row.user_id as string,
+      body: row.body as string,
+      created_at: row.created_at as string,
+      like_count: likeCounts.get(row.id as number) ?? 0,
+      author,
+    }
+  })
+
+  items.sort((a, b) => {
+    if (b.like_count !== a.like_count) return b.like_count - a.like_count
+    return b.created_at.localeCompare(a.created_at)
+  })
+  return items.slice(0, limit)
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,10 +18,12 @@ export type UserRow = {
 
 export type PollOption = { id: number; label: string }
 
+export type PostType = 'text' | 'poll' | 'question'
+
 export type PostRow = {
   id: number
   user_id: string
-  type: 'text' | 'poll'
+  type: PostType
   body: string
   tags: string[]
   show_contact: boolean
@@ -30,7 +32,19 @@ export type PostRow = {
   poll_multi: boolean | null
   poll_deadline: string | null
   poll_hide_results: boolean | null
+  question_target_user_id: string | null
   created_at: string
+}
+
+export type ScreenMode = 'default' | 'qa' | 'lottery'
+
+export type EventStateRow = {
+  id: number
+  current_section: 'p1' | 'p2' | 'breakout' | 'panel' | null
+  override_until: string | null
+  screen_mode: ScreenMode
+  qa_host_user_id: string | null
+  updated_at: string
 }
 
 // match_intent moved to its own table (migration 0011) so it cannot leak via

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,7 +44,21 @@ export type EventStateRow = {
   override_until: string | null
   screen_mode: ScreenMode
   qa_host_user_id: string | null
+  lottery_draw_id: number | null
   updated_at: string
+}
+
+export type LotteryRules = {
+  must_have_posted: boolean
+  exclude_previous_winners: boolean
+}
+
+export type LotteryDrawRow = {
+  id: number
+  rules: LotteryRules
+  pool_user_ids: string[]
+  winner_user_id: string
+  created_at: string
 }
 
 // match_intent moved to its own table (migration 0011) so it cannot leak via

--- a/supabase/migrations/0015_screen_modes_qa.sql
+++ b/supabase/migrations/0015_screen_modes_qa.sql
@@ -1,0 +1,58 @@
+-- =====================================================================
+-- 0015_screen_modes_qa.sql — /screen 模式状态机 + QA 提问数据模型 (issue #27)
+-- =====================================================================
+-- 三种 screen_mode：
+--   default — 默认骨架（大 QR + LIVE 板块演讲信息）
+--   qa      — 嘉宾 QA 模式，主办方触发，观众端浮 banner「向 X 提问」
+--   lottery — 抽奖模式（migration 0016 扩展）
+--
+-- QA host: event_state.qa_host_user_id 指向被提问的嘉宾 user。
+-- 提问帖：posts.type='question' + posts.question_target_user_id 指向 host。
+--
+-- event_state 进 publication —— /screen 和 /feed 都需要在 admin 切模式时
+-- 几乎实时反应。⚠️ 应用本 migration 后必须在 Supabase Dashboard
+-- → Database → Publications → supabase_realtime 把 event_state toggle 一下
+-- （关再开），否则 Realtime 内部状态不会重载（已踩过的坑）。
+
+-- 1. event_state 加 screen_mode + qa_host_user_id
+alter table event_state add column screen_mode text not null default 'default';
+alter table event_state add column qa_host_user_id uuid references users(id) on delete set null;
+
+alter table event_state add constraint event_state_screen_mode_valid
+  check (screen_mode in ('default', 'qa', 'lottery'));
+
+-- qa_host_user_id 只在 screen_mode='qa' 时有意义。其它模式下应为 null。
+alter table event_state add constraint event_state_qa_host_consistency
+  check (
+    (screen_mode = 'qa' and qa_host_user_id is not null)
+    or (screen_mode <> 'qa' and qa_host_user_id is null)
+  );
+
+-- 2. posts 加 'question' type + question_target_user_id
+alter table posts drop constraint posts_type_check;
+alter table posts add constraint posts_type_check
+  check (type in ('text', 'poll', 'question'));
+
+alter table posts add column question_target_user_id uuid
+  references users(id) on delete set null;
+
+-- question_target_user_id 只在 type='question' 时有意义。
+alter table posts add constraint posts_question_target_consistency
+  check (
+    (type = 'question' and question_target_user_id is not null)
+    or (type <> 'question' and question_target_user_id is null)
+  );
+
+create index posts_question_target_idx
+  on posts (question_target_user_id, created_at desc)
+  where question_target_user_id is not null;
+
+-- 3. event_state 上 RLS + anon read，加进 publication
+alter table event_state enable row level security;
+
+create policy "anon read event_state"
+  on event_state for select
+  to anon
+  using (true);
+
+alter publication supabase_realtime add table event_state;

--- a/supabase/migrations/0016_lottery.sql
+++ b/supabase/migrations/0016_lottery.sql
@@ -1,0 +1,45 @@
+-- =====================================================================
+-- 0016_lottery.sql — 大屏抽奖 (issue #27)
+-- =====================================================================
+-- 设计要点：
+--   1. winner 在 admin 点「开始抽奖」时由 server 已经选定写入 winner_user_id。
+--      前端动画只是视觉表演，无法影响结果（防作弊）。
+--   2. lottery_draws 不进 publication，anon 读不到 — pool_user_ids 列表
+--      包含所有候选 user_id，泄露面会扩大现场可见范围。/screen 通过
+--      service_role 服务端读取（fetchScreenData）。
+--   3. event_state.lottery_draw_id 引用当前抽奖行；event_state 已经在
+--      publication 里，所以 /screen 切模式 + 抽奖切换都靠这一条 broadcast 触发。
+--   4. status 字段不要 — 有 winner_user_id 就代表已经定。重抽 = 新建一行。
+--   5. 排除上轮中奖者 = 看历史 lottery_draws.winner_user_id 排除即可。
+
+create table lottery_draws (
+  id bigserial primary key,
+  -- {must_have_posted: bool, exclude_previous_winners: bool}
+  rules jsonb not null default '{}'::jsonb,
+  -- 抽签时刻的候选池快照（uuid 数组），动画用
+  pool_user_ids uuid[] not null,
+  -- 服务端在 insert 时已选好；动画只是视觉
+  winner_user_id uuid not null references users(id) on delete restrict,
+  created_at timestamptz not null default now()
+);
+
+create index lottery_draws_created_at_idx on lottery_draws (created_at desc);
+create index lottery_draws_winner_idx on lottery_draws (winner_user_id);
+
+-- event_state 加 lottery_draw_id 字段
+alter table event_state add column lottery_draw_id bigint
+  references lottery_draws(id) on delete set null;
+
+-- 重写 mode 一致性约束，包含 lottery 分支
+alter table event_state drop constraint event_state_qa_host_consistency;
+alter table event_state add constraint event_state_mode_consistency check (
+  (screen_mode = 'qa'      and qa_host_user_id is not null and lottery_draw_id is null)
+  or (screen_mode = 'lottery' and qa_host_user_id is null     and lottery_draw_id is not null)
+  or (screen_mode = 'default' and qa_host_user_id is null     and lottery_draw_id is null)
+);
+
+-- RLS 启用但不写 anon policy = anon 完全读不到（pool_user_ids 隐私）
+alter table lottery_draws enable row level security;
+
+-- 注意：不要 alter publication add table lottery_draws —— 隐私 + 不需要
+-- 客户端订阅，/screen 走 event_state.lottery_draw_id 触发服务端 refetch。


### PR DESCRIPTION
Closes #27.

## Summary
- **默认骨架**：删掉热帖滚动 + 2×2 grid，主位换成大 QR + 密码 + 当前 LIVE 板块演讲信息 + 在线人数。投票 takeover 不动。
- **嘉宾 QA**：admin 触发（不是 VIP），从 VIP dropdown 选目标嘉宾。观众端 PostComposer 上方自动出现「向 X 提问」rose 色 banner（QuestionComposer），大屏 QaSlot 左侧大字 host info + QR，右侧按 like_count desc 取顶 13 条提问（顶 5 大字号 + 8 ticker）。
- **抽奖**：服务端开抽时已选 winner 写库（防作弊，前端只播 5s 减速旋转动画然后定格），rules = 必须发过帖（默认关）+ 排除上轮中奖（默认开），池子 = 在线 5 分钟内。

## Architecture
状态机 \`event_state.screen_mode\` ∈ {default, qa, lottery}，DB 约束保证字段一致性：default 时 host/draw 都 null，qa 时 host 必填，lottery 时 draw 必填。\`event_state\` 进 publication（migration 0015），\`/screen\` + \`/feed\` 都订阅它，admin 一切模式两端瞬时响应。\`lottery_draws\` 反过来不进 publication（pool_user_ids 隐私），通过 \`event_state.lottery_draw_id\` 变化触发服务端 refetch 间接广播。

## Migrations
- \`0015_screen_modes_qa.sql\` — event_state 加 screen_mode + qa_host_user_id；posts 加 type='question' + question_target_user_id；event_state 进 publication
- \`0016_lottery.sql\` — lottery_draws 表 + event_state.lottery_draw_id + 重写 mode_consistency 约束

⚠️ **应用 0015 后必须在 Supabase Dashboard → Database → Publications → supabase_realtime 把 event_state toggle 一下**（关再开），否则 Realtime 不会重载（已踩过的坑，记 in CLAUDE.md）。

## Test plan
- [ ] 应用 migration 0015 / 0016；Dashboard toggle event_state publication
- [ ] /screen default 模式：检查 QR 大、LIVE 信息、在线人数
- [ ] admin 控制台 → 选 VIP → 开始 QA → /feed 自动出现 QuestionComposer banner，大屏切到 QA 视图
- [ ] 多账号在 /feed 提问 + 互相点赞 → /screen 顶 5 排序按 likes
- [ ] admin 结束 QA → 两端回 default
- [ ] admin 开始抽奖（exclude_previous_winners=on）→ /screen 5s 旋转动画，定格中奖人
- [ ] 再开一次抽奖 → 上轮中奖人确实被排除（pool 中没他）
- [ ] admin 结束抽奖 → 回 default
- [ ] iPhone Chrome 测 QuestionComposer：发问 → 大屏出现（form action progressive enhancement）

🤖 Generated with [Claude Code](https://claude.com/claude-code)