### PR TITLE
fix(qa): /feed 加 QA 提问区块，支持点赞 (#29)

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -45,10 +45,21 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
   // Fire-and-forget; don't await on the render path.
   void touchLastSeen(user.id)
 
-  const [posts, unreadMe] = await Promise.all([
+  const qaHostId = modeState.mode === 'qa' ? modeState.qa_host_user_id : null
+
+  const [posts, unreadMe, qaQuestionsRaw] = await Promise.all([
     fetchFeed(user.id, { section }),
     fetchUnreadMe(user),
+    qaHostId
+      ? fetchFeed(user.id, { questionTargetUserId: qaHostId, limit: 50 })
+      : Promise.resolve([]),
   ])
+  // 大屏按 like_count desc 排，这里同步保持一致 — 观众点赞会让自己关心的问题顶上去。
+  const qaQuestions = [...qaQuestionsRaw].sort((a, b) => {
+    if (b.like_count !== a.like_count) return b.like_count - a.like_count
+    return b.created_at.localeCompare(a.created_at)
+  })
+
   const viewerCanDm = isNonAnon(user)
 
   return (
@@ -65,12 +76,31 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
         <div className="mt-4 space-y-4">
           <OnboardingBanner />
           {modeState.mode === 'qa' && modeState.qa_host_name && (
-            <QuestionComposer
-              hostName={modeState.qa_host_name}
-              hostTitle={modeState.qa_host_title}
-              defaultNickname={user.nickname}
-              defaultCompany={user.company}
-            />
+            <>
+              <QuestionComposer
+                hostName={modeState.qa_host_name}
+                hostTitle={modeState.qa_host_title}
+                defaultNickname={user.nickname}
+                defaultCompany={user.company}
+              />
+              {qaQuestions.length > 0 && (
+                <section className="space-y-2">
+                  <h2 className="px-1 text-sm font-semibold text-rose-700">
+                    向「{modeState.qa_host_name}」提问 · 按点赞排序
+                  </h2>
+                  <div className="space-y-3">
+                    {qaQuestions.map((post) => (
+                      <PostCard
+                        key={post.id}
+                        post={post}
+                        viewerId={user.id}
+                        viewerCanDm={viewerCanDm}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
+            </>
           )}
           <PostComposer
             defaultNickname={user.nickname}

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
-import { getCurrentUser, touchLastSeen } from '@/lib/identity'
+import { getCurrentUser, readAdminCookie, touchLastSeen } from '@/lib/identity'
 import { Header } from '@/components/Header'
 import { EventHero } from '@/components/EventHero'
 import { PostComposer } from '@/components/PostComposer'
@@ -46,19 +46,34 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
   void touchLastSeen(user.id)
 
   const qaHostId = modeState.mode === 'qa' ? modeState.qa_host_user_id : null
+  // 上一轮 QA：只有 mode=default 时显示塌陷区块（避免 lottery 模式下也来唠叨）。
+  const lastQaHostId =
+    modeState.mode === 'default' ? modeState.last_qa_host_user_id : null
 
-  const [posts, unreadMe, qaQuestionsRaw] = await Promise.all([
-    fetchFeed(user.id, { section }),
-    fetchUnreadMe(user),
-    qaHostId
-      ? fetchFeed(user.id, { questionTargetUserId: qaHostId, limit: 50 })
-      : Promise.resolve([]),
-  ])
+  const [posts, unreadMe, qaQuestionsRaw, lastQaQuestionsRaw, viewerIsAdmin] =
+    await Promise.all([
+      fetchFeed(user.id, { section }),
+      fetchUnreadMe(user),
+      qaHostId
+        ? fetchFeed(user.id, { questionTargetUserId: qaHostId, limit: 50 })
+        : Promise.resolve([]),
+      lastQaHostId
+        ? fetchFeed(user.id, { questionTargetUserId: lastQaHostId, limit: 50 })
+        : Promise.resolve([]),
+      readAdminCookie(),
+    ])
   // 大屏按 like_count desc 排，这里同步保持一致 — 观众点赞会让自己关心的问题顶上去。
-  const qaQuestions = [...qaQuestionsRaw].sort((a, b) => {
-    if (b.like_count !== a.like_count) return b.like_count - a.like_count
-    return b.created_at.localeCompare(a.created_at)
-  })
+  // 同时把 answered 的沉到底（即使点赞高也不挤占）。
+  const sortQuestions = (xs: typeof qaQuestionsRaw) =>
+    [...xs].sort((a, b) => {
+      const aDone = a.answered_at ? 1 : 0
+      const bDone = b.answered_at ? 1 : 0
+      if (aDone !== bDone) return aDone - bDone
+      if (b.like_count !== a.like_count) return b.like_count - a.like_count
+      return b.created_at.localeCompare(a.created_at)
+    })
+  const qaQuestions = sortQuestions(qaQuestionsRaw)
+  const lastQaQuestions = sortQuestions(lastQaQuestionsRaw)
 
   const viewerCanDm = isNonAnon(user)
 
@@ -95,12 +110,37 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
                         post={post}
                         viewerId={user.id}
                         viewerCanDm={viewerCanDm}
+                        viewerIsAdmin={viewerIsAdmin}
                       />
                     ))}
                   </div>
                 </section>
               )}
             </>
+          )}
+          {/* 上一轮 QA 归档：默认塌陷，可展开。结束 QA 时 host 已被搬到 last_qa_host_user_id */}
+          {lastQaHostId && lastQaQuestions.length > 0 && modeState.last_qa_host_name && (
+            <details className="group rounded-2xl border border-zinc-200 bg-zinc-50/60 px-4 py-3 [&_summary::-webkit-details-marker]:hidden">
+              <summary className="flex cursor-pointer items-center justify-between text-sm text-zinc-700">
+                <span>
+                  上一轮 QA · 向「{modeState.last_qa_host_name}」 ·{' '}
+                  <span className="text-zinc-500">{lastQaQuestions.length} 个问题</span>
+                </span>
+                <span className="text-xs text-zinc-400 group-open:hidden">展开 ↓</span>
+                <span className="hidden text-xs text-zinc-400 group-open:inline">收起 ↑</span>
+              </summary>
+              <div className="mt-3 space-y-3">
+                {lastQaQuestions.map((post) => (
+                  <PostCard
+                    key={post.id}
+                    post={post}
+                    viewerId={user.id}
+                    viewerCanDm={viewerCanDm}
+                    viewerIsAdmin={viewerIsAdmin}
+                  />
+                ))}
+              </div>
+            </details>
           )}
           <PostComposer
             defaultNickname={user.nickname}
@@ -119,7 +159,13 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
           ) : (
             <div className="space-y-3">
               {posts.map((post) => (
-                <PostCard key={post.id} post={post} viewerId={user.id} viewerCanDm={viewerCanDm} />
+                <PostCard
+                  key={post.id}
+                  post={post}
+                  viewerId={user.id}
+                  viewerCanDm={viewerCanDm}
+                  viewerIsAdmin={viewerIsAdmin}
+                />
               ))}
             </div>
           )}

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -4,21 +4,31 @@ import { useState, useSyncExternalStore, useTransition } from 'react'
 import type { FeedPost } from '@/lib/queries/posts'
 import { displayName, displayMeta } from '@/lib/display'
 import { POST_MAX_CHARS } from '@/lib/constants'
-import { deletePostAction, updatePostAction } from '@/lib/actions/posts'
+import {
+  deletePostAction,
+  setQuestionAnsweredAction,
+  updatePostAction,
+} from '@/lib/actions/posts'
 import { Avatar } from './Avatar'
 import { LikeButton } from './LikeButton'
 import { PollCard } from './PollCard'
 import { ReplySection } from './ReplySection'
 import { UserCardTrigger } from './UserCard'
 
-type Props = { post: FeedPost; viewerId: string; viewerCanDm: boolean }
+type Props = {
+  post: FeedPost
+  viewerId: string
+  viewerCanDm: boolean
+  viewerIsAdmin?: boolean
+}
 
-export function PostCard({ post, viewerId, viewerCanDm }: Props) {
+export function PostCard({ post, viewerId, viewerCanDm, viewerIsAdmin = false }: Props) {
   const author = post.author
   const name = displayName(author)
   const meta = displayMeta(author)
   const isPoll = post.type === 'poll'
   const isQuestion = post.type === 'question'
+  const isAnswered = isQuestion && !!post.answered_at
   const isMine = post.user_id === viewerId
 
   const [editing, setEditing] = useState(false)
@@ -63,14 +73,24 @@ export function PostCard({ post, viewerId, viewerCanDm }: Props) {
     })
   }
 
+  function onToggleAnswered() {
+    setError(null)
+    startTransition(async () => {
+      const res = await setQuestionAnsweredAction(post.id, !isAnswered)
+      if (res.error) setError(res.error)
+    })
+  }
+
   return (
     <article
       id={`post-${post.id}`}
       className={
         'scroll-mt-20 rounded-2xl border bg-white p-4 shadow-sm transition-shadow hover:shadow-md ' +
-        (isQuestion
-          ? 'border-rose-200 border-l-4 border-l-rose-400 bg-rose-50/40'
-          : 'border-zinc-200')
+        (isAnswered
+          ? 'border-zinc-200 border-l-4 border-l-zinc-300 bg-zinc-50/60 opacity-70'
+          : isQuestion
+            ? 'border-rose-200 border-l-4 border-l-rose-400 bg-rose-50/40'
+            : 'border-zinc-200')
       }
     >
       <header className="mb-2 flex items-center gap-2 text-sm">
@@ -94,12 +114,33 @@ export function PostCard({ post, viewerId, viewerCanDm }: Props) {
             投票
           </span>
         )}
-        {isQuestion && (
+        {isQuestion && !isAnswered && (
           <span className="rounded-full bg-rose-100 px-2 py-0.5 text-[11px] font-medium text-rose-700">
             提问
           </span>
         )}
+        {isAnswered && (
+          <span className="rounded-full bg-zinc-200 px-2 py-0.5 text-[11px] font-medium text-zinc-600">
+            已答 ✓
+          </span>
+        )}
         <span className="ml-auto text-xs text-zinc-400"><RelativeTime iso={post.created_at} /></span>
+        {viewerIsAdmin && isQuestion && (
+          <button
+            type="button"
+            onClick={onToggleAnswered}
+            disabled={pending}
+            className={
+              'rounded px-1.5 py-0.5 text-xs disabled:opacity-50 ' +
+              (isAnswered
+                ? 'text-zinc-500 hover:bg-zinc-100 hover:text-zinc-800'
+                : 'text-rose-600 hover:bg-rose-100 hover:text-rose-800')
+            }
+            title="主办方专用：标记问题是否已被嘉宾回答"
+          >
+            {isAnswered ? '取消已答' : '标已答'}
+          </button>
+        )}
         {isMine && !editing && (
           <div className="flex items-center gap-1">
             {!isPoll && !isQuestion && (

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -18,6 +18,7 @@ export function PostCard({ post, viewerId, viewerCanDm }: Props) {
   const name = displayName(author)
   const meta = displayMeta(author)
   const isPoll = post.type === 'poll'
+  const isQuestion = post.type === 'question'
   const isMine = post.user_id === viewerId
 
   const [editing, setEditing] = useState(false)
@@ -63,7 +64,15 @@ export function PostCard({ post, viewerId, viewerCanDm }: Props) {
   }
 
   return (
-    <article id={`post-${post.id}`} className="scroll-mt-20 rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md">
+    <article
+      id={`post-${post.id}`}
+      className={
+        'scroll-mt-20 rounded-2xl border bg-white p-4 shadow-sm transition-shadow hover:shadow-md ' +
+        (isQuestion
+          ? 'border-rose-200 border-l-4 border-l-rose-400 bg-rose-50/40'
+          : 'border-zinc-200')
+      }
+    >
       <header className="mb-2 flex items-center gap-2 text-sm">
         <UserCardTrigger
           user={{ id: post.user_id, ...author }}
@@ -85,10 +94,15 @@ export function PostCard({ post, viewerId, viewerCanDm }: Props) {
             投票
           </span>
         )}
+        {isQuestion && (
+          <span className="rounded-full bg-rose-100 px-2 py-0.5 text-[11px] font-medium text-rose-700">
+            提问
+          </span>
+        )}
         <span className="ml-auto text-xs text-zinc-400"><RelativeTime iso={post.created_at} /></span>
         {isMine && !editing && (
           <div className="flex items-center gap-1">
-            {!isPoll && (
+            {!isPoll && !isQuestion && (
               <button
                 type="button"
                 onClick={() => setEditing(true)}

--- a/src/components/screen/ScreenAdminBar.tsx
+++ b/src/components/screen/ScreenAdminBar.tsx
@@ -10,6 +10,7 @@ import {
   exitScreenModeAction,
   startLotteryAction,
 } from '@/lib/actions/event-state'
+import { markAllCurrentQaAnsweredAction } from '@/lib/actions/posts'
 import { SECTIONS, isSectionId, type SectionId } from '@/lib/sections'
 import type { ScreenMode } from '@/lib/types'
 import type { VipForDropdown } from '@/lib/queries/event-state'
@@ -83,6 +84,15 @@ export function ScreenAdminBar({ currentSection, screenMode, qaHostUserId, vips 
         must_have_posted: mustHavePosted,
         exclude_previous_winners: excludePreviousWinners,
       })
+      if (res.error) setError(res.error)
+    })
+  }
+
+  function markAllAnswered() {
+    if (!window.confirm('把当前 QA 所有未答问题都标为已答？大屏会清空。')) return
+    setError(null)
+    startTransition(async () => {
+      const res = await markAllCurrentQaAnsweredAction()
       if (res.error) setError(res.error)
     })
   }
@@ -191,14 +201,26 @@ export function ScreenAdminBar({ currentSection, screenMode, qaHostUserId, vips 
               </div>
             </div>
           ) : (
-            <button
-              type="button"
-              onClick={exitMode}
-              disabled={pending}
-              className="w-full rounded-md bg-zinc-700 px-2 py-1.5 text-xs font-medium text-zinc-100 hover:bg-zinc-600 disabled:opacity-50"
-            >
-              {screenMode === 'qa' ? '结束 QA' : '结束抽奖'}（回默认骨架）
-            </button>
+            <div className="space-y-1.5">
+              {screenMode === 'qa' && (
+                <button
+                  type="button"
+                  onClick={markAllAnswered}
+                  disabled={pending}
+                  className="w-full rounded-md border border-zinc-600 bg-zinc-800 px-2 py-1.5 text-xs font-medium text-zinc-100 hover:bg-zinc-700 disabled:opacity-50"
+                >
+                  全部标已答（清空大屏）
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={exitMode}
+                disabled={pending}
+                className="w-full rounded-md bg-zinc-700 px-2 py-1.5 text-xs font-medium text-zinc-100 hover:bg-zinc-600 disabled:opacity-50"
+              >
+                {screenMode === 'qa' ? '结束 QA' : '结束抽奖'}（回默认骨架）
+              </button>
+            </div>
           )}
         </fieldset>
 

--- a/src/lib/actions/event-state.ts
+++ b/src/lib/actions/event-state.ts
@@ -89,20 +89,29 @@ export async function startQaAction(
 }
 
 // 退出 QA / lottery，回到 default 骨架。
+// QA 结束时把当前 host 搬到 last_qa_host_user_id，给 /feed「上一轮 QA」
+// 塌陷区块用。lottery 结束不做归档（中奖人由 lottery_draws 表保留）。
 export async function exitScreenModeAction(): Promise<{ error: string | null }> {
   if (!(await readAdminCookie())) return { error: '未授权' }
 
   const sb = getServerSupabase()
-  const { error } = await sb
+  const { data: cur } = await sb
     .from('event_state')
-    .update({
-      screen_mode: 'default',
-      qa_host_user_id: null,
-      lottery_draw_id: null,
-      updated_at: new Date().toISOString(),
-    })
+    .select('screen_mode, qa_host_user_id')
     .eq('id', 1)
+    .maybeSingle()
 
+  const updates: Record<string, unknown> = {
+    screen_mode: 'default',
+    qa_host_user_id: null,
+    lottery_draw_id: null,
+    updated_at: new Date().toISOString(),
+  }
+  if (cur?.screen_mode === 'qa' && cur.qa_host_user_id) {
+    updates.last_qa_host_user_id = cur.qa_host_user_id
+  }
+
+  const { error } = await sb.from('event_state').update(updates).eq('id', 1)
   if (error) return { error: error.message }
   revalidatePath('/screen')
   revalidatePath('/feed')

--- a/src/lib/actions/posts.ts
+++ b/src/lib/actions/posts.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import { getCurrentUser } from '@/lib/identity'
+import { getCurrentUser, readAdminCookie } from '@/lib/identity'
 import { getServerSupabase } from '@/lib/supabase/server'
 import { POST_MAX_CHARS, MATCH_INTENT_MAX_CHARS } from '@/lib/constants'
 import { isSectionId } from '@/lib/sections'
@@ -170,6 +170,59 @@ export async function createQuestionAction(
   revalidatePath('/feed')
   revalidatePath('/screen')
   return { error: null, ok: true }
+}
+
+// =====================================================================
+// QA: 标记问题已答 (issue #29) — admin 专属
+// =====================================================================
+export async function setQuestionAnsweredAction(
+  postId: number,
+  answered: boolean,
+): Promise<PostMutationResult> {
+  if (!(await readAdminCookie())) return { error: '未授权' }
+  if (!Number.isInteger(postId) || postId <= 0) return { error: '帖子 id 不对' }
+
+  const sb = getServerSupabase()
+  const { data, error } = await sb
+    .from('posts')
+    .update({ answered_at: answered ? new Date().toISOString() : null })
+    .eq('id', postId)
+    .eq('type', 'question')
+    .select('id')
+    .maybeSingle()
+
+  if (error) return { error: error.message }
+  if (!data) return { error: '没找到这条提问' }
+
+  revalidatePath('/feed')
+  revalidatePath('/screen')
+  return { error: null }
+}
+
+// 批量标记当前 QA host 的所有未答问题为已答 — 切换轮次时清场。
+export async function markAllCurrentQaAnsweredAction(): Promise<PostMutationResult> {
+  if (!(await readAdminCookie())) return { error: '未授权' }
+
+  const sb = getServerSupabase()
+  const { data: state } = await sb
+    .from('event_state')
+    .select('qa_host_user_id')
+    .eq('id', 1)
+    .maybeSingle()
+  if (!state?.qa_host_user_id) return { error: '当前没有进行中的 QA' }
+
+  const { error } = await sb
+    .from('posts')
+    .update({ answered_at: new Date().toISOString() })
+    .eq('type', 'question')
+    .eq('question_target_user_id', state.qa_host_user_id)
+    .is('answered_at', null)
+
+  if (error) return { error: error.message }
+
+  revalidatePath('/feed')
+  revalidatePath('/screen')
+  return { error: null }
 }
 
 export async function deletePostAction(postId: number): Promise<PostMutationResult> {

--- a/src/lib/queries/event-state.ts
+++ b/src/lib/queries/event-state.ts
@@ -29,6 +29,10 @@ export type ScreenModeState = {
   qa_host_user_id: string | null
   qa_host_name: string | null
   qa_host_title: string | null
+  // 上一轮 QA 的 host（exit 时归档），给 /feed 塌陷区块用；
+  // 当 mode='qa' 时这俩字段不应该被用（用 qa_host_* 即可）。
+  last_qa_host_user_id: string | null
+  last_qa_host_name: string | null
   lottery_draw_id: number | null
 }
 
@@ -38,7 +42,9 @@ export async function getScreenModeState(): Promise<ScreenModeState> {
   const { data } = await sb
     .from('event_state')
     .select(
-      'screen_mode, qa_host_user_id, lottery_draw_id, host:users!qa_host_user_id ( vip_name, nickname, vip_title, company )',
+      `screen_mode, qa_host_user_id, last_qa_host_user_id, lottery_draw_id,
+       host:users!qa_host_user_id ( vip_name, nickname, vip_title, company ),
+       last_host:users!last_qa_host_user_id ( vip_name, nickname )`,
     )
     .eq('id', 1)
     .maybeSingle()
@@ -49,6 +55,8 @@ export async function getScreenModeState(): Promise<ScreenModeState> {
       qa_host_user_id: null,
       qa_host_name: null,
       qa_host_title: null,
+      last_qa_host_user_id: null,
+      last_qa_host_name: null,
       lottery_draw_id: null,
     }
   }
@@ -59,8 +67,11 @@ export async function getScreenModeState(): Promise<ScreenModeState> {
     vip_title: string | null
     company: string | null
   }
+  type LastHostRow = { vip_name: string | null; nickname: string | null }
   const hostRel = (data as { host?: HostRow | HostRow[] | null }).host
   const host = Array.isArray(hostRel) ? hostRel[0] ?? null : hostRel ?? null
+  const lastHostRel = (data as { last_host?: LastHostRow | LastHostRow[] | null }).last_host
+  const lastHost = Array.isArray(lastHostRel) ? lastHostRel[0] ?? null : lastHostRel ?? null
 
   const mode = (data.screen_mode as ScreenMode) ?? 'default'
   return {
@@ -68,6 +79,8 @@ export async function getScreenModeState(): Promise<ScreenModeState> {
     qa_host_user_id: (data.qa_host_user_id as string | null) ?? null,
     qa_host_name: host ? host.vip_name ?? host.nickname ?? null : null,
     qa_host_title: host ? host.vip_title ?? host.company ?? null : null,
+    last_qa_host_user_id: (data.last_qa_host_user_id as string | null) ?? null,
+    last_qa_host_name: lastHost ? lastHost.vip_name ?? lastHost.nickname ?? null : null,
     lottery_draw_id: (data.lottery_draw_id as number | null) ?? null,
   }
 }

--- a/src/lib/queries/posts.ts
+++ b/src/lib/queries/posts.ts
@@ -49,7 +49,13 @@ export type FeedPost = PostRow & {
 
 export async function fetchFeed(
   viewerId: string,
-  opts: { limit?: number; authorId?: string; section?: SectionId } = {},
+  opts: {
+    limit?: number
+    authorId?: string
+    section?: SectionId
+    // QA: 拉某 host 的全部 question 帖（绕过 section filter）。
+    questionTargetUserId?: string
+  } = {},
 ): Promise<FeedPost[]> {
   const sb = getServerSupabase()
   const limit = opts.limit ?? 100
@@ -72,7 +78,16 @@ export async function fetchFeed(
     .limit(limit)
 
   if (opts.authorId) postsQuery = postsQuery.eq('user_id', opts.authorId)
-  if (opts.section) postsQuery = postsQuery.eq('section', opts.section)
+  if (opts.questionTargetUserId) {
+    // QA 模式：只要这个 host 的 question 帖。section/type 都不限。
+    postsQuery = postsQuery
+      .eq('type', 'question')
+      .eq('question_target_user_id', opts.questionTargetUserId)
+  } else {
+    // 常规 timeline / /me：question 帖走独立区块（/feed 的 QA 区），不进 section feed。
+    postsQuery = postsQuery.in('type', ['text', 'poll'])
+    if (opts.section) postsQuery = postsQuery.eq('section', opts.section)
+  }
 
   const [postsRes, likesRes, votesRes] = await Promise.all([
     postsQuery,

--- a/src/lib/queries/posts.ts
+++ b/src/lib/queries/posts.ts
@@ -65,7 +65,7 @@ export async function fetchFeed(
     .select(
       `id, user_id, type, body, tags, show_contact, section,
        poll_options, poll_multi, poll_deadline, poll_hide_results,
-       question_target_user_id,
+       question_target_user_id, answered_at,
        created_at,
        author:users!user_id ( nickname, company, contact_handle, show_contact, is_vip, vip_name, vip_title ),
        replies (

--- a/src/lib/queries/questions.ts
+++ b/src/lib/queries/questions.ts
@@ -35,6 +35,8 @@ export async function fetchQuestionsForHost(
       )
       .eq('type', 'question')
       .eq('question_target_user_id', hostUserId)
+      // 大屏只显示未答问题 — admin 在 /feed 标已答后立刻让出位置
+      .is('answered_at', null)
       .order('created_at', { ascending: false })
       .limit(100),
     sb.from('likes').select('post_id'),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -33,6 +33,7 @@ export type PostRow = {
   poll_deadline: string | null
   poll_hide_results: boolean | null
   question_target_user_id: string | null
+  answered_at: string | null
   created_at: string
 }
 
@@ -44,6 +45,7 @@ export type EventStateRow = {
   override_until: string | null
   screen_mode: ScreenMode
   qa_host_user_id: string | null
+  last_qa_host_user_id: string | null
   lottery_draw_id: number | null
   updated_at: string
 }

--- a/supabase/migrations/0017_qa_answered_archive.sql
+++ b/supabase/migrations/0017_qa_answered_archive.sql
@@ -1,0 +1,24 @@
+-- =====================================================================
+-- 0017_qa_answered_archive.sql — QA 结束归档 + 已答标记 (issue #29)
+-- =====================================================================
+-- 两件事同 PR 解决：
+--   1. QA 结束后 /feed 仍能看到「上一轮 QA」展开区块 — 加
+--      event_state.last_qa_host_user_id，exit 时把当前 host 搬过去。
+--   2. 多轮 QA 老问题霸占顶 5 — 加 posts.answered_at；admin 标记
+--      已答的问题不再上大屏，给新问题腾位。
+
+-- 1. event_state.last_qa_host_user_id
+alter table event_state add column last_qa_host_user_id uuid
+  references users(id) on delete set null;
+
+-- 2. posts.answered_at
+alter table posts add column answered_at timestamptz;
+
+-- 部分索引：大屏 QaSlot 热路径 — 取某 host 的未答问题。
+create index posts_unanswered_question_idx
+  on posts (question_target_user_id, created_at desc)
+  where type = 'question' and answered_at is null;
+
+-- posts 已经在 publication 里（migration 0002），所以 answered_at 字段
+-- update 后会自动通过 posts 行 broadcast 给 anon。/feed 和 /screen
+-- 都订阅 posts，标记后会自动 router.refresh()，无需额外配置。


### PR DESCRIPTION
Closes #29.

## 根因
QuestionComposer 写入 \`section=null\`（QA 是跨 section 的全局模式），
但 \`/feed\` 的 \`fetchFeed\` 一直用 \`.eq('section', ...)\` 过滤
→ question 帖在任何 section tab 下都看不到 → 观众没法点赞。

## 修法
- \`fetchFeed\` 加 \`questionTargetUserId\` 选项，触发时绕过 section filter，只拉该 host 的 question 帖。
- \`fetchFeed\` 默认（section / authorId 路径）显式 \`.in('type', ['text', 'poll'])\`，避免 question 帖意外混进 section timeline 或 \`/me\`。
- \`/feed\` 在 \`mode='qa'\` 时 parallel fetch QA 提问，按 \`like_count desc\` 排序（与 \`/screen\` 一致），渲染在 QuestionComposer 下方独立区块「向 X 提问 · 按点赞排序」，复用 PostCard 自然支持点赞。

## Test plan
- [ ] admin 起 QA → 提问 → /feed 顶端出现该问题
- [ ] 多账号点赞 → 排序立刻顶上去（FeedRealtime 会触发 router.refresh）
- [ ] /screen 大屏排序与 /feed 一致
- [ ] section tab 切换不显示 question 帖；/me 也不显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)