### PR TITLE
chore(deploy): switch CF target to live.nl-dams.com

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,5 +32,5 @@ export NEXT_PUBLIC_EVENT_ORGANIZER="DAMS"
 echo "→ Building Worker bundle"
 npx opennextjs-cloudflare build
 
-echo "→ Deploying to meet.zhaidewei.com"
+echo "→ Deploying to live.nl-dams.com"
 exec npx opennextjs-cloudflare deploy

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "main": ".open-next/worker.js",
   "name": "dams-meetup",
+  "account_id": "f1dc30bb93206c310ab2b840baceb857",
   "compatibility_date": "2026-04-01",
   "compatibility_flags": [
     "nodejs_compat",
@@ -21,6 +22,6 @@
     "enabled": true
   },
   "routes": [
-    { "pattern": "meet.zhaidewei.com", "custom_domain": true }
+    { "pattern": "live.nl-dams.com", "custom_domain": true }
   ]
 }


### PR DESCRIPTION
## Summary
- Switch Cloudflare Workers deploy target from `meet.zhaidewei.com` to `live.nl-dams.com`
- Pin `account_id` in `wrangler.jsonc` to friend's CF account (`f1dc30bb93206c310ab2b840baceb857`) where the `nl-dams.com` zone lives
- Update `scripts/deploy.sh` echo string to match

## Context
Original plan was to host on my personal CF account (`meet.zhaidewei.com`). For DAMS #14 we're piggy-backing on a friend's account that already owns `nl-dams.com`. First deploy + runtime secrets push already done from this branch; Workers Builds (GitHub auto-deploy) connected on friend's dashboard with build env vars configured.

## Test plan
- [x] `npm run deploy` from this branch succeeds against friend's account
- [x] `./scripts/cf-secrets-push.sh` populates runtime secrets in target worker
- [x] `https://live.nl-dams.com/` serves password gate (HTTP 200)
- [ ] Workers Builds end-to-end: merge this PR → CF auto-builds → live site reflects merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)