### PR TITLE
feat(theme): indigo → blue + DM 气泡内文字左对齐

### DIFF
--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -192,7 +192,7 @@ function FoldableList<T>({
       </div>
       {tail.length > 0 && (
         <details className="mt-2">
-          <summary className="flex cursor-pointer list-none items-center gap-1 px-1 py-1 text-xs text-indigo-600 hover:text-indigo-700">
+          <summary className="flex cursor-pointer list-none items-center gap-1 px-1 py-1 text-xs text-blue-600 hover:text-blue-700">
             <span className="underline underline-offset-2">查看其余 {tail.length} 条</span>
           </summary>
           <div className={`mt-2 ${gapClass}`}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,16 +34,16 @@ export default async function HomePage({
   const recoveryFailed = sp.error === 'recovery'
 
   return (
-    <main className="flex min-h-svh flex-col items-center bg-gradient-to-b from-indigo-50 via-white to-white px-6 py-12">
+    <main className="flex min-h-svh flex-col items-center bg-gradient-to-b from-blue-50 via-white to-white px-6 py-12">
       <div className="w-full max-w-2xl space-y-10">
         <header className="space-y-2 text-center">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-indigo-600">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-600">
             {EVENT_ORGANIZER}
           </p>
           <h1 className="text-2xl font-semibold text-zinc-900">{EVENT_NAME}</h1>
         </header>
 
-        <div className="mx-auto w-full max-w-sm space-y-6 rounded-2xl border border-indigo-100 bg-white/80 p-6 shadow-sm backdrop-blur">
+        <div className="mx-auto w-full max-w-sm space-y-6 rounded-2xl border border-blue-100 bg-white/80 p-6 shadow-sm backdrop-blur">
           <form action={loginAction} className="space-y-4">
             <div>
               <label htmlFor="password" className="block text-sm text-zinc-700 mb-1.5">
@@ -56,7 +56,7 @@ export default async function HomePage({
                 required
                 autoFocus
                 autoComplete="off"
-                className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2.5 text-base focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2.5 text-base focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
               {showError && <p className="mt-2 text-sm text-red-600">密码不对</p>}
               {recoveryFailed && (
@@ -68,7 +68,7 @@ export default async function HomePage({
 
             <button
               type="submit"
-              className="w-full rounded-lg bg-indigo-600 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-indigo-700"
+              className="w-full rounded-lg bg-blue-600 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700"
             >
               进入
             </button>
@@ -80,7 +80,7 @@ export default async function HomePage({
 
           <p className="text-center text-xs text-zinc-500">
             嘉宾请走
-            <a href="/vip-login" className="ml-1 text-indigo-600 underline underline-offset-2 hover:text-indigo-700">
+            <a href="/vip-login" className="ml-1 text-blue-600 underline underline-offset-2 hover:text-blue-700">
               嘉宾登录
             </a>
           </p>

--- a/src/app/vip-login/page.tsx
+++ b/src/app/vip-login/page.tsx
@@ -18,10 +18,10 @@ export default async function VipLoginPage({
         : null
 
   return (
-    <main className="flex min-h-svh flex-col items-center justify-center bg-gradient-to-b from-indigo-50 via-white to-white px-6 py-12">
+    <main className="flex min-h-svh flex-col items-center justify-center bg-gradient-to-b from-blue-50 via-white to-white px-6 py-12">
       <div className="w-full max-w-sm space-y-8">
         <header className="space-y-2 text-center">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-indigo-600">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-600">
             {EVENT_ORGANIZER}
           </p>
           <h1 className="text-2xl font-semibold text-zinc-900">{EVENT_NAME}</h1>
@@ -30,7 +30,7 @@ export default async function VipLoginPage({
 
         <form
           action={vipLoginAction}
-          className="space-y-4 rounded-2xl border border-indigo-100 bg-white/80 p-6 shadow-sm backdrop-blur"
+          className="space-y-4 rounded-2xl border border-blue-100 bg-white/80 p-6 shadow-sm backdrop-blur"
         >
           <div>
             <label htmlFor="username" className="mb-1.5 block text-sm text-zinc-700">
@@ -43,7 +43,7 @@ export default async function VipLoginPage({
               required
               autoFocus
               autoComplete="username"
-              className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2.5 text-base text-zinc-900 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2.5 text-base text-zinc-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
 
@@ -57,14 +57,14 @@ export default async function VipLoginPage({
               type="password"
               required
               autoComplete="current-password"
-              className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2.5 text-base text-zinc-900 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="w-full rounded-lg border border-zinc-300 bg-white px-3 py-2.5 text-base text-zinc-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
             {errMsg && <p className="mt-2 text-sm text-red-600">{errMsg}</p>}
           </div>
 
           <button
             type="submit"
-            className="w-full rounded-lg bg-indigo-600 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-indigo-700"
+            className="w-full rounded-lg bg-blue-600 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700"
           >
             进入
           </button>
@@ -72,7 +72,7 @@ export default async function VipLoginPage({
 
         <p className="text-center text-xs text-zinc-500">
           普通参会者请走
-          <Link href="/" className="ml-1 text-indigo-600 underline underline-offset-2 hover:text-indigo-700">
+          <Link href="/" className="ml-1 text-blue-600 underline underline-offset-2 hover:text-blue-700">
             活动密码入口
           </Link>
         </p>

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -27,7 +27,7 @@ export function CopyButton({ text, className }: Props) {
       onClick={copy}
       className={
         className ??
-        'inline-flex shrink-0 items-center gap-1 rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition-colors hover:bg-indigo-700'
+        'inline-flex shrink-0 items-center gap-1 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition-colors hover:bg-blue-700'
       }
     >
       {copied ? <Check className="size-3.5" aria-hidden /> : <Copy className="size-3.5" aria-hidden />}

--- a/src/components/DmThreadList.tsx
+++ b/src/components/DmThreadList.tsx
@@ -47,7 +47,7 @@ function ThreadRow({ thread, viewerId }: { thread: DmThreadSummary; viewerId: st
     <div className="relative">
       <Link
         href={`/me/dm/${thread.thread_id}`}
-        className="flex items-center gap-3 rounded-2xl border border-zinc-200 bg-white p-3 pr-12 shadow-sm transition-colors hover:border-indigo-300 hover:bg-indigo-50/30"
+        className="flex items-center gap-3 rounded-2xl border border-zinc-200 bg-white p-3 pr-12 shadow-sm transition-colors hover:border-blue-300 hover:bg-blue-50/30"
       >
         <Avatar seed={thread.other.id} user={thread.other} size="md" />
         <div className="min-w-0 flex-1">

--- a/src/components/DmThreadView.tsx
+++ b/src/components/DmThreadView.tsx
@@ -101,7 +101,7 @@ export function DmThreadView({
             maxLength={DM_MAX_CHARS}
             rows={3}
             placeholder="说点什么…"
-            className="w-full resize-none rounded-md border border-zinc-200 bg-white px-3 py-2 text-[15px] focus:border-indigo-400 focus:outline-none"
+            className="w-full resize-none rounded-md border border-zinc-200 bg-white px-3 py-2 text-[15px] focus:border-blue-400 focus:outline-none"
           />
           <div className="flex items-center justify-end gap-2 text-xs">
             <span className={remaining < 0 ? 'text-red-500' : 'text-zinc-400'}>
@@ -111,7 +111,7 @@ export function DmThreadView({
               type="button"
               onClick={onSend}
               disabled={pending || body.trim().length === 0 || remaining < 0}
-              className="rounded-lg bg-indigo-600 px-3 py-1 text-xs font-medium text-white shadow-sm transition-colors hover:bg-indigo-700 disabled:bg-zinc-300"
+              className="rounded-lg bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow-sm transition-colors hover:bg-blue-700 disabled:bg-zinc-300"
             >
               {pending ? '发送中…' : '发送'}
             </button>
@@ -130,22 +130,17 @@ export function DmThreadView({
 function MessageBubble({ message, mine }: { message: DmMessageRow; mine: boolean }) {
   return (
     <div className={mine ? 'flex justify-end' : 'flex justify-start'}>
-      <div className={'max-w-[80%] space-y-1 ' + (mine ? 'text-right' : 'text-left')}>
+      <div className={'flex max-w-[80%] flex-col space-y-1 ' + (mine ? 'items-end' : 'items-start')}>
         <div
           className={
-            'inline-block whitespace-pre-wrap rounded-2xl px-3 py-2 text-[15px] leading-relaxed ' +
-            (mine ? 'bg-indigo-600 text-white' : 'bg-zinc-100 text-zinc-800')
+            'whitespace-pre-wrap rounded-2xl px-3 py-2 text-[15px] leading-relaxed ' +
+            (mine ? 'bg-blue-600 text-white' : 'bg-zinc-100 text-zinc-800')
           }
         >
           {message.body}
         </div>
         {message.revealed_contact && (
-          <div
-            className={
-              'inline-flex items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1 text-[11px] text-amber-800 ' +
-              (mine ? 'ml-auto' : '')
-            }
-          >
+          <div className="inline-flex items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1 text-[11px] text-amber-800">
             <Phone className="size-3" aria-hidden />
             <span>{message.revealed_contact}</span>
             <CopyButton

--- a/src/components/EventHero.tsx
+++ b/src/components/EventHero.tsx
@@ -32,10 +32,10 @@ export function EventHero({ liveSection }: Props) {
   const liveMeta = liveSection ? SECTION_META[liveSection] : null
 
   return (
-    <section className="relative overflow-hidden rounded-2xl border border-indigo-100 bg-gradient-to-br from-indigo-50 via-white to-white p-4 shadow-sm">
+    <section className="relative overflow-hidden rounded-2xl border border-blue-100 bg-gradient-to-br from-blue-50 via-white to-white p-4 shadow-sm">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-indigo-600">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-blue-600">
             DAMS
           </p>
           <h1 className="text-base font-semibold text-zinc-900">{EVENT_NAME}</h1>
@@ -51,7 +51,7 @@ export function EventHero({ liveSection }: Props) {
       {liveSection && liveMeta ? (
         <Link
           href={`/feed?section=${liveSection}`}
-          className="mt-3 flex items-center gap-2 rounded-xl bg-white/80 px-3 py-2 text-sm text-zinc-700 ring-1 ring-indigo-100 transition-colors hover:bg-white"
+          className="mt-3 flex items-center gap-2 rounded-xl bg-white/80 px-3 py-2 text-sm text-zinc-700 ring-1 ring-blue-100 transition-colors hover:bg-white"
         >
           <span className="relative flex size-2 shrink-0">
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-rose-400 opacity-75" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -41,7 +41,7 @@ function NavTab({
       className={
         'relative rounded-lg px-2.5 py-1.5 transition-colors ' +
         (active
-          ? 'bg-indigo-600 text-white shadow-sm'
+          ? 'bg-blue-600 text-white shadow-sm'
           : 'text-zinc-600 hover:bg-zinc-100')
       }
     >

--- a/src/components/MeIdentityBar.tsx
+++ b/src/components/MeIdentityBar.tsx
@@ -30,7 +30,7 @@ export function MeIdentityBar({ user }: Props) {
   }
 
   return (
-    <div className="flex items-center gap-3 rounded-2xl border border-indigo-100 bg-gradient-to-br from-indigo-50 via-white to-white p-3 shadow-sm">
+    <div className="flex items-center gap-3 rounded-2xl border border-blue-100 bg-gradient-to-br from-blue-50 via-white to-white p-3 shadow-sm">
       <Avatar seed={user.id} user={user} size="md" />
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2 text-sm">
@@ -49,7 +49,7 @@ export function MeIdentityBar({ user }: Props) {
       <button
         type="button"
         onClick={openSettings}
-        className="shrink-0 rounded-lg border border-indigo-200 bg-white px-2.5 py-1 text-xs font-medium text-indigo-700 hover:bg-indigo-50"
+        className="shrink-0 rounded-lg border border-blue-200 bg-white px-2.5 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50"
       >
         编辑
       </button>

--- a/src/components/OnboardingBanner.tsx
+++ b/src/components/OnboardingBanner.tsx
@@ -37,22 +37,22 @@ export function OnboardingBanner() {
   if (!mounted || !open) return null
 
   return (
-    <div className="rounded-2xl border border-indigo-200 bg-indigo-50 p-4 shadow-sm">
+    <div className="rounded-2xl border border-blue-200 bg-blue-50 p-4 shadow-sm">
       <div className="mb-2 flex items-baseline justify-between gap-3">
-        <h3 className="flex items-center gap-1.5 text-sm font-semibold text-indigo-900">
+        <h3 className="flex items-center gap-1.5 text-sm font-semibold text-blue-900">
           <Hand className="size-4" aria-hidden />
           第一次来？三件事
         </h3>
         <button
           type="button"
           onClick={dismiss}
-          className="-mr-1 rounded p-1 text-indigo-700 hover:bg-indigo-100"
+          className="-mr-1 rounded p-1 text-blue-700 hover:bg-blue-100"
           aria-label="关闭"
         >
           <X className="size-3.5" aria-hidden />
         </button>
       </div>
-      <ul className="space-y-1.5 text-sm text-indigo-900">
+      <ul className="space-y-1.5 text-sm text-blue-900">
         <li>
           <span className="font-medium">默认匿名</span>
           ：发帖不显示你是谁。想让人认出你 → 点「编辑身份」填昵称 / 公司 / 联系方式。
@@ -60,7 +60,7 @@ export function OnboardingBanner() {
         <li>
           <span className="font-medium">AI 撮合</span>
           ：发帖时可以暗中委托「想找 Booking 的同学聊内推」之类，结果只回到你自己的「我」tab。
-          <span className="text-indigo-700"> 想让对方找到你 → 先填昵称 + 联系方式。</span>
+          <span className="text-blue-700"> 想让对方找到你 → 先填昵称 + 联系方式。</span>
         </li>
         <li>
           <span className="font-medium">嘉宾发投票</span>
@@ -71,7 +71,7 @@ export function OnboardingBanner() {
         <button
           type="button"
           onClick={dismiss}
-          className="rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition-colors hover:bg-indigo-700"
+          className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition-colors hover:bg-blue-700"
         >
           知道了，不再提示
         </button>

--- a/src/components/PollCard.tsx
+++ b/src/components/PollCard.tsx
@@ -63,7 +63,7 @@ export function PollCard({
             <label
               key={opt.id}
               className={
-                'relative block w-full cursor-pointer overflow-hidden rounded-lg border border-zinc-200 bg-white px-3 py-2 text-left text-sm transition-colors has-[:checked]:border-indigo-500 has-[:checked]:ring-1 has-[:checked]:ring-indigo-300' +
+                'relative block w-full cursor-pointer overflow-hidden rounded-lg border border-zinc-200 bg-white px-3 py-2 text-left text-sm transition-colors has-[:checked]:border-blue-500 has-[:checked]:ring-1 has-[:checked]:ring-blue-300' +
                 (closed ? ' cursor-default' : '')
               }
             >
@@ -72,7 +72,7 @@ export function PollCard({
                   aria-hidden
                   className={
                     'pointer-events-none absolute inset-y-0 left-0 ' +
-                    (isMine ? 'bg-indigo-500/15' : 'bg-zinc-200/60')
+                    (isMine ? 'bg-blue-500/15' : 'bg-zinc-200/60')
                   }
                   style={{ width: `${pct}%` }}
                 />
@@ -89,7 +89,7 @@ export function PollCard({
                 <span
                   aria-hidden
                   className={
-                    'inline-flex size-4 shrink-0 items-center justify-center border border-zinc-300 bg-white peer-checked:border-indigo-600 peer-checked:bg-indigo-600 ' +
+                    'inline-flex size-4 shrink-0 items-center justify-center border border-zinc-300 bg-white peer-checked:border-blue-600 peer-checked:bg-blue-600 ' +
                     (multi ? 'rounded-sm' : 'rounded-full')
                   }
                 />
@@ -118,7 +118,7 @@ export function PollCard({
           <button
             type="submit"
             disabled={isPending}
-            className="rounded-lg bg-indigo-600 px-3 py-1 text-xs font-medium text-white shadow-sm transition-colors hover:bg-indigo-700 disabled:bg-zinc-300"
+            className="rounded-lg bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow-sm transition-colors hover:bg-blue-700 disabled:bg-zinc-300"
           >
             {isPending ? '提交中…' : hasVoted ? '改投' : '投票'}
           </button>

--- a/src/components/PollComposer.tsx
+++ b/src/components/PollComposer.tsx
@@ -115,7 +115,7 @@ export function PollComposer({
           <input
             type="checkbox"
             name="multi"
-            className="size-4 rounded border-zinc-300 text-indigo-600 focus:ring-indigo-400"
+            className="size-4 rounded border-zinc-300 text-blue-600 focus:ring-blue-400"
           />
           多选
         </label>
@@ -123,7 +123,7 @@ export function PollComposer({
           <input
             type="checkbox"
             name="hide_results"
-            className="size-4 rounded border-zinc-300 text-indigo-600 focus:ring-indigo-400"
+            className="size-4 rounded border-zinc-300 text-blue-600 focus:ring-blue-400"
           />
           投票前隐藏结果
         </label>

--- a/src/components/PostComposer.tsx
+++ b/src/components/PostComposer.tsx
@@ -160,8 +160,8 @@ export function PostComposer({
       )}
 
       {matchOpen && (
-        <div className="space-y-1.5 rounded-xl border border-indigo-200 bg-indigo-50/60 p-3">
-          <div className="flex items-baseline justify-between text-xs text-indigo-900">
+        <div className="space-y-1.5 rounded-xl border border-blue-200 bg-blue-50/60 p-3">
+          <div className="flex items-baseline justify-between text-xs text-blue-900">
             <span className="flex items-center gap-1.5 font-medium">
               <Sparkles className="size-3.5" aria-hidden />
               委托 AI 撮合（私下，仅你可见）
@@ -169,7 +169,7 @@ export function PostComposer({
             <button
               type="button"
               onClick={() => setMatchOpen(false)}
-              className="rounded p-1 text-indigo-700 hover:bg-indigo-100"
+              className="rounded p-1 text-blue-700 hover:bg-blue-100"
               aria-label="收起 AI 撮合"
             >
               <X className="size-3.5" aria-hidden />
@@ -200,11 +200,11 @@ export function PostComposer({
             maxLength={MATCH_INTENT_MAX_CHARS}
             placeholder="比如：想找 Booking 的同学聊内推 / 想找会 dbt 的人 / 想找做 PM 的同行聊聊"
             rows={2}
-            className="w-full resize-none rounded-md border border-indigo-200 bg-white px-2.5 py-1.5 text-sm placeholder:text-zinc-400 focus:border-indigo-400 focus:outline-none"
+            className="w-full resize-none rounded-md border border-blue-200 bg-white px-2.5 py-1.5 text-sm placeholder:text-zinc-400 focus:border-blue-400 focus:outline-none"
           />
-          <div className="space-y-1 text-[11px] text-indigo-700">
+          <div className="space-y-1 text-[11px] text-blue-700">
             <p>这条不进时间线，结果以回帖形式仅你可见。</p>
-            <p className="flex items-start gap-1 text-indigo-800">
+            <p className="flex items-start gap-1 text-blue-800">
               <AlertTriangle className="mt-0.5 size-3 shrink-0" aria-hidden />
               <span>
                 内容会发往 DeepSeek API。请勿在此填邮箱 / 电话 / 微信号；系统已做基础过滤但不能保证 100% 拦截。
@@ -225,8 +225,8 @@ export function PostComposer({
           className={
             'flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium transition-colors ' +
             (matchOpen
-              ? 'border-indigo-400 bg-indigo-100 text-indigo-900'
-              : 'border-zinc-200 bg-white text-zinc-600 hover:border-indigo-300 hover:bg-indigo-50 hover:text-indigo-800')
+              ? 'border-blue-400 bg-blue-100 text-blue-900'
+              : 'border-zinc-200 bg-white text-zinc-600 hover:border-blue-300 hover:bg-blue-50 hover:text-blue-800')
           }
         >
           <Sparkles className="size-3.5" aria-hidden />
@@ -235,7 +235,7 @@ export function PostComposer({
         <button
           type="submit"
           disabled={isPending}
-          className="rounded-lg bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-indigo-700 disabled:bg-zinc-400"
+          className="rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700 disabled:bg-zinc-400"
         >
           {isPending ? '发送中…' : '发帖'}
         </button>

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -53,7 +53,7 @@ export function ProfileForm({
             name="nickname"
             defaultValue={defaultNickname ?? ''}
             placeholder="昵称"
-            className="w-full rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+            className="w-full rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 focus:outline-none focus:ring-1 focus:ring-blue-400"
           />
         </Field>
         <Field label={isVip ? '公司（留空用嘉宾默认 title）' : '公司'}>
@@ -61,7 +61,7 @@ export function ProfileForm({
             name="company"
             defaultValue={defaultCompany ?? ''}
             placeholder="公司"
-            className="w-full rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+            className="w-full rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 focus:outline-none focus:ring-1 focus:ring-blue-400"
           />
         </Field>
         <div className="sm:col-span-2">
@@ -70,7 +70,7 @@ export function ProfileForm({
               name="contact_handle"
               defaultValue={defaultContactHandle ?? ''}
               placeholder="例如 linkedin.com/in/your-id"
-              className="w-full rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+              className="w-full rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-900 focus:outline-none focus:ring-1 focus:ring-blue-400"
             />
           </Field>
         </div>
@@ -81,7 +81,7 @@ export function ProfileForm({
           type="checkbox"
           name="show_contact"
           defaultChecked={defaultShowContact}
-          className="size-4 rounded border-zinc-300 text-indigo-600 focus:ring-indigo-400"
+          className="size-4 rounded border-zinc-300 text-blue-600 focus:ring-blue-400"
         />
         公开联系方式（其他人点你头像可看 / 复制）
       </label>
@@ -93,7 +93,7 @@ export function ProfileForm({
         <button
           type="submit"
           disabled={isPending}
-          className="rounded-lg bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-indigo-700 disabled:bg-zinc-400"
+          className="rounded-lg bg-blue-600 px-4 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-700 disabled:bg-zinc-400"
         >
           {isPending ? '保存中…' : '保存'}
         </button>

--- a/src/components/RecoveryLink.tsx
+++ b/src/components/RecoveryLink.tsx
@@ -14,7 +14,7 @@ export async function RecoveryLink({ uid, token }: Props) {
   const url = `${origin}/recover?u=${uid}&t=${token}`
 
   return (
-    <div className="rounded-2xl border border-indigo-100 bg-indigo-50/50 p-4 shadow-sm">
+    <div className="rounded-2xl border border-blue-100 bg-blue-50/50 p-4 shadow-sm">
       <h2 className="mb-1 text-sm font-semibold text-zinc-900">恢复链接</h2>
       <p className="mb-3 text-xs text-zinc-600">
         换浏览器或清缓存后，用这个链接找回身份（活动结束 7 天内有效）
@@ -23,7 +23,7 @@ export async function RecoveryLink({ uid, token }: Props) {
         <input
           readOnly
           value={url}
-          className="flex-1 rounded-md border border-indigo-200 bg-white px-2.5 py-1.5 font-mono text-xs text-zinc-800 focus:outline-none"
+          className="flex-1 rounded-md border border-blue-200 bg-white px-2.5 py-1.5 font-mono text-xs text-zinc-800 focus:outline-none"
         />
         <CopyButton text={url} />
       </div>

--- a/src/components/ReplySection.tsx
+++ b/src/components/ReplySection.tsx
@@ -178,14 +178,14 @@ export function ReplySection({ postId, count, replies, viewerId, viewerCanDm }: 
             <input type="hidden" name="post_id" value={postId} />
             <input type="hidden" name="parent_reply_id" value={replyingTo?.id ?? ''} />
             {replyingTo && (
-              <div className="flex items-center justify-between rounded-md bg-indigo-50 px-2 py-1 text-xs text-indigo-800">
+              <div className="flex items-center justify-between rounded-md bg-blue-50 px-2 py-1 text-xs text-blue-800">
                 <span>
                   正在回复 <span className="font-medium">@{replyingTo.name}</span>
                 </span>
                 <button
                   type="button"
                   onClick={onCancelReplyingTo}
-                  className="rounded p-1 text-indigo-700 hover:bg-indigo-100"
+                  className="rounded p-1 text-blue-700 hover:bg-blue-100"
                   aria-label="取消回复对象"
                 >
                   <X className="size-3" aria-hidden />
@@ -207,7 +207,7 @@ export function ReplySection({ postId, count, replies, viewerId, viewerCanDm }: 
               <button
                 type="submit"
                 disabled={isPending}
-                className="rounded-lg bg-indigo-600 px-3 py-1 text-xs font-medium text-white shadow-sm transition-colors hover:bg-indigo-700 disabled:bg-zinc-400"
+                className="rounded-lg bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow-sm transition-colors hover:bg-blue-700 disabled:bg-zinc-400"
               >
                 {isPending ? '发送中…' : '回复'}
               </button>
@@ -377,7 +377,7 @@ function ReplyBody({ body }: { body: string }) {
   if (!m) return <p className="whitespace-pre-wrap text-zinc-800">{body}</p>
   return (
     <p className="whitespace-pre-wrap text-zinc-800">
-      <span className="font-medium text-indigo-700">{m[1]}</span>
+      <span className="font-medium text-blue-700">{m[1]}</span>
       {m[2]}
       {m[3]}
     </p>
@@ -397,21 +397,21 @@ function AiReplyRow({
   const targetName = m ? displayName(m) : null
   const isMine = m ? m.id === viewerId : false
   return (
-    <div className="rounded-xl border border-indigo-200 bg-indigo-50 px-3 py-2 text-sm">
+    <div className="rounded-xl border border-blue-200 bg-blue-50 px-3 py-2 text-sm">
       <div className="mb-1 flex flex-wrap items-center gap-2 text-xs">
-        <Sparkles className="size-3.5 self-center text-indigo-700" aria-hidden />
-        <span className="font-medium text-indigo-900">AI 撮合</span>
-        <span className="rounded-full bg-indigo-100 px-1.5 py-px text-[10px] text-indigo-800">
+        <Sparkles className="size-3.5 self-center text-blue-700" aria-hidden />
+        <span className="font-medium text-blue-900">AI 撮合</span>
+        <span className="rounded-full bg-blue-100 px-1.5 py-px text-[10px] text-blue-800">
           仅你可见
         </span>
         {m && targetName && (
-          <span className="inline-flex items-center gap-1 text-indigo-700">
+          <span className="inline-flex items-center gap-1 text-blue-700">
             推荐：
             <UserCardTrigger
               user={m}
               viewerCanDm={viewerCanDm}
               isMine={isMine}
-              className="inline-flex items-center gap-1.5 rounded-md px-1 py-0.5 text-indigo-800"
+              className="inline-flex items-center gap-1.5 rounded-md px-1 py-0.5 text-blue-800"
             >
               <Avatar seed={m.id} user={m} size="sm" />
               <span className="font-medium underline decoration-dotted underline-offset-2">

--- a/src/components/SectionTabs.tsx
+++ b/src/components/SectionTabs.tsx
@@ -26,7 +26,7 @@ export function SectionTabs({ active, live }: Props) {
                 className={
                   'flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors ' +
                   (isActive
-                    ? 'bg-indigo-600 text-white shadow-sm'
+                    ? 'bg-blue-600 text-white shadow-sm'
                     : 'bg-zinc-100 text-zinc-700 hover:bg-zinc-200')
                 }
               >

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -154,7 +154,7 @@ function UserCardDialog({
             type="button"
             onClick={onDm}
             disabled={pending}
-            className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 disabled:bg-zinc-400"
+            className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 disabled:bg-zinc-400"
           >
             <Send className="size-4" aria-hidden />
             {pending ? '打开中…' : '发私信'}
@@ -178,19 +178,19 @@ function ContactPill({ text }: { text: string }) {
       // clipboard 被浏览器拦截：不致命
     }
   }
-  const iconClass = 'size-3.5 shrink-0 text-zinc-500 group-hover:text-indigo-600'
+  const iconClass = 'size-3.5 shrink-0 text-zinc-500 group-hover:text-blue-600'
   return (
     <button
       type="button"
       onClick={copy}
       title={copied ? '已复制' : '点击复制'}
-      className="group mt-4 inline-flex w-full max-w-full items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs text-zinc-700 transition-colors hover:border-indigo-300 hover:bg-indigo-50"
+      className="group mt-4 inline-flex w-full max-w-full items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-xs text-zinc-700 transition-colors hover:border-blue-300 hover:bg-blue-50"
     >
       {kind === 'url' && <Link2 className={iconClass} aria-hidden />}
       {kind === 'email' && <AtSign className={iconClass} aria-hidden />}
       {kind === 'other' && <UserCircle2 className={iconClass} aria-hidden />}
       <span className="truncate text-left font-medium text-zinc-800">{text}</span>
-      <span className="ml-auto inline-flex shrink-0 items-center gap-1 text-[11px] text-zinc-500 group-hover:text-indigo-700">
+      <span className="ml-auto inline-flex shrink-0 items-center gap-1 text-[11px] text-zinc-500 group-hover:text-blue-700">
         {copied ? (
           <>
             <Check className="size-3" aria-hidden />

--- a/src/components/screen/ScreenAdminBar.tsx
+++ b/src/components/screen/ScreenAdminBar.tsx
@@ -246,7 +246,7 @@ export function ScreenAdminBar({ currentSection, screenMode, qaHostUserId, vips 
                   className={
                     'rounded-md px-2 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 ' +
                     (active
-                      ? 'bg-indigo-500 text-white'
+                      ? 'bg-blue-500 text-white'
                       : 'bg-zinc-800 text-zinc-200 hover:bg-zinc-700')
                   }
                 >
@@ -277,7 +277,7 @@ export function ScreenAdminBar({ currentSection, screenMode, qaHostUserId, vips 
               className={
                 'rounded-md px-2 py-1.5 text-xs font-medium transition-colors ' +
                 (filterSection === null
-                  ? 'bg-indigo-500 text-white'
+                  ? 'bg-blue-500 text-white'
                   : 'bg-zinc-800 text-zinc-200 hover:bg-zinc-700')
               }
             >
@@ -293,7 +293,7 @@ export function ScreenAdminBar({ currentSection, screenMode, qaHostUserId, vips 
                   className={
                     'rounded-md px-2 py-1.5 text-xs font-medium transition-colors ' +
                     (active
-                      ? 'bg-indigo-500 text-white'
+                      ? 'bg-blue-500 text-white'
                       : 'bg-zinc-800 text-zinc-200 hover:bg-zinc-700')
                   }
                 >

--- a/src/components/screen/ScreenView.tsx
+++ b/src/components/screen/ScreenView.tsx
@@ -265,10 +265,10 @@ function PollSlot({
 
   return (
     <div className="grid h-full grid-cols-[1.6fr_1fr] gap-6">
-    <div className="grid grid-rows-[auto_1fr_auto] gap-6 rounded-2xl bg-indigo-500/10 px-10 py-8 ring-1 ring-indigo-500/30">
+    <div className="grid grid-rows-[auto_1fr_auto] gap-6 rounded-2xl bg-blue-500/10 px-10 py-8 ring-1 ring-blue-500/30">
       <div>
         <div className="mb-2 flex items-center gap-3">
-          <span className="rounded-full bg-indigo-500 px-3 py-1 text-sm font-semibold text-white">
+          <span className="rounded-full bg-blue-500 px-3 py-1 text-sm font-semibold text-white">
             投票进行中
           </span>
           <PostHeader post={post} />
@@ -289,7 +289,7 @@ function PollSlot({
             >
               <div
                 aria-hidden
-                className="absolute inset-y-0 left-0 bg-indigo-500/35"
+                className="absolute inset-y-0 left-0 bg-blue-500/35"
                 style={{ width: `${pct}%` }}
               />
               <div className="relative flex items-center gap-4 px-6 py-4">

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -14,7 +14,7 @@ type AvatarUser = {
 }
 
 const PALETTE = [
-  'bg-indigo-500',
+  'bg-blue-500',
   'bg-emerald-500',
   'bg-rose-500',
   'bg-amber-500',


### PR DESCRIPTION
## Summary
- 主题色：21 个文件 76 处 `indigo-*` → `blue-*`（同 shade 一对一），对齐母站 nl-dams.com 的品牌蓝（`blue-600 ≈ #2563eb`）。DAMS #14 站现在 host 在 nl-dams.com 子域，色调统一让用户感知是同一组织。
- 私信修复：自己消息气泡**位置仍然贴右**，但**气泡内部文字改为左对齐**（之前因父级用 `text-right` 推 inline-block 气泡而连带让气泡内文字也右对齐——把 layout 改用 `flex flex-col + items-end/items-start`，layout 由 flex 决定、内文 align 自然回到默认）。

## Test plan
- [x] `tsc --noEmit` 通过
- [x] `eslint src` 通过
- [ ] 浏览器目测：
  - [x] `/` 密码 gate 按钮变蓝
  - [ ] `/feed` tab、按钮、AI 撮合卡片、头像调色板蓝色
  - [x] `/me` 私信 thread：自己气泡贴右、内文左对齐；对方气泡贴左、内文左对齐

🤖 Generated with [Claude Code](https://claude.com/claude-code)