### PR TITLE
feat(sections): add 公共讨论区 lounge as first section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,7 @@ Then point Claude at this file: it contains all the architectural decisions and 
 6. **端到端验证 match function 真跑通** — 部署完成但还没观测到 match_runs 表里有 success 行；至少塞 ≥3 条暗需求 mock 数据后等下一次 cron（5min），或 admin force token 手动触发，验证 DeepSeek 调用+ AI reply 写回
 
 ### Recently shipped
+- 2026-05-06: **issue #32 — 新增「公共讨论区」板块 lounge** — `lounge` 加到 `SECTIONS` 第一位，无 `SECTION_WINDOWS` 项（永远开放、`sectionByClock` 永不命中、admin 显式覆写才能成 LIVE）。`DEFAULT_SECTION` 由 `p1` → `lounge`，活动外/空档期 /feed 默认跳 lounge。migration 0018 放宽 `posts.section` 与 `event_state.current_section` 的 CHECK 约束。admin 大屏「当前 LIVE 板块」「视图筛选」两个旋钮自动出现 lounge 选项，"全部" 自然包含 lounge 帖。
 - 2026-05-05: **CF 部署切到朋友账户 `live.nl-dams.com` (PR #31)** — wrangler.jsonc pin `account_id` + custom_domain route；本地首次 deploy → runtime secrets push → Workers Builds 接 `zhaidewei/dams-meetup` repo 自动 build & deploy。朋友 CF 账户给的 role：`Workers Admin` + `Administrator Read Only`（后者补 Account Settings Read，否则 Workers Builds connect 会报权限错）。Build env vars (NEXT_PUBLIC_*) 必须在朋友 dashboard 单独配，不走 `scripts/deploy.sh` 的 Keychain 注入路径。
 - 2026-05-03 傍晚: **issue #17 — 投票手动关闭 + DeepSeek 数据声明 + redact 兜底** — `closePollAction` 把 `poll_deadline` 提前到 now()（复用既有字段，无新状态列），PollCard 给作者显示「立即截止」按钮；`prompt.ts` 加 `redactContacts()`（邮箱/URL/≥10 数字串 → `[已隐藏]`），UI 显式声明数据流向 DeepSeek。`docs/matching-design.md` §8 完整字段清单。
 - 2026-05-03 傍晚: **issue #15 — 联系方式一键复制** — PostCard / DmThreadView 展示对方联系方式时附复制按钮（复用 RecoveryLink 同款 CopyButton）。

--- a/src/lib/sections.ts
+++ b/src/lib/sections.ts
@@ -1,7 +1,9 @@
-// 4 event sections — splits the timeline into separate discussion streams.
-// Backend stores `posts.section` (text, nullable). Constraint in 0005.
+// Event sections — splits the timeline into separate discussion streams.
+// Backend stores `posts.section` (text, nullable). Constraint in 0005 + 0018.
+// `lounge` 是脱离会议议程的公共讨论区，没有时间窗，永远开放；放第一位。
 
 export const SECTIONS = [
+  { id: 'lounge', label: '公共讨论区' },
   { id: 'p1', label: '演讲 1' },
   { id: 'p2', label: '演讲 2' },
   { id: 'breakout', label: '分组交流' },
@@ -10,7 +12,7 @@ export const SECTIONS = [
 
 export type SectionId = (typeof SECTIONS)[number]['id']
 
-export const DEFAULT_SECTION: SectionId = 'p1'
+export const DEFAULT_SECTION: SectionId = 'lounge'
 
 const SECTION_IDS = SECTIONS.map((s) => s.id) as readonly string[]
 
@@ -48,6 +50,11 @@ export type SectionMeta = {
 }
 
 export const SECTION_META: Record<SectionId, SectionMeta> = {
+  lounge: {
+    topic: '不限主题，自由发帖、求助、组队、招聘',
+    speaker: null,
+    affiliation: null,
+  },
   p1: {
     topic: '和 AI 搭档：合作、摩擦与重新定义工作',
     speaker: '刘爵铭',

--- a/supabase/migrations/0018_lounge_section.sql
+++ b/supabase/migrations/0018_lounge_section.sql
@@ -1,0 +1,20 @@
+-- =====================================================================
+-- 0018_lounge_section.sql — 增加 `lounge` 公共讨论区板块（issue #32）
+-- =====================================================================
+-- 不归属任何会议主题、无时间窗，永远开放；UI 上排第一位。
+-- 需要把两个 CHECK 约束都加上 'lounge'：
+--   posts.section          (0005)
+--   event_state.current_section (0014)
+
+alter table posts drop constraint if exists posts_section_check;
+alter table posts
+  add constraint posts_section_check
+  check (section is null or section in ('lounge', 'p1', 'p2', 'breakout', 'panel'));
+
+alter table event_state drop constraint if exists event_state_section_valid;
+alter table event_state
+  add constraint event_state_section_valid
+  check (
+    current_section is null
+    or current_section in ('lounge', 'p1', 'p2', 'breakout', 'panel')
+  );


### PR DESCRIPTION
Closes #32

## Summary
- 新增 `lounge`（公共讨论区）板块，放在 `SECTIONS` 第一位
- 不绑定任何会议主题，无时间窗，永远开放
- `sectionByClock` 永不自动命中 lounge — admin 显式覆写才能成 LIVE
- `DEFAULT_SECTION` 由 `p1` → `lounge`，活动外/空档期 /feed 默认跳 lounge
- migration 0018 放宽 `posts.section` + `event_state.current_section` 的 CHECK 约束（已应用到线上）

## 旋钮交互（与 admin 商定）
| 当前 LIVE | 大屏视图筛选 | 行为 |
|---|---|---|
| admin 覆写=lounge | — | 暖场 / 收场，全场公共讨论 |
| (空档期) | — | 默认回落到 lounge |
| p1/p2/... | 全部 | 含 lounge 的全板块流（大屏现已不显示帖子，无抢屏问题）|

## Test plan
- [x] `tsc --noEmit` 通过
- [x] `eslint src` 通过
- [x] vitest 44/44 通过
- [x] migration 0018 已应用到线上 DB
- [ ] 手机/桌面 /feed 看到第一个 tab 是「公共讨论区」并能发帖
- [ ] /screen admin bar 两个旋钮都出现 lounge 按钮

🤖 Generated with [Claude Code](https://claude.com/claude-code)