### PR TITLE
fix(qa): bind questions to active section + click-to-mark answered

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -45,10 +45,19 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
   // Fire-and-forget; don't await on the render path.
   void touchLastSeen(user.id)
 
-  const qaHostId = modeState.mode === 'qa' ? modeState.qa_host_user_id : null
-  // 上一轮 QA：只有 mode=default 时显示塌陷区块（避免 lottery 模式下也来唠叨）。
+  // QA 与 section 绑定（issue #37）：只在当前查看的 section 与 qa_section 匹配时
+  // 渲染 QA UI。qa_section 为 null（活动外/空档期启动）时退化为「所有 section 下都显示」。
+  const qaSectionMatches =
+    modeState.qa_section === null || modeState.qa_section === section
+  const qaHostId =
+    modeState.mode === 'qa' && qaSectionMatches ? modeState.qa_host_user_id : null
+  // 上一轮 QA：只有 mode=default 且 section 匹配时显示塌陷区块。
+  const lastQaSectionMatches =
+    modeState.last_qa_section === null || modeState.last_qa_section === section
   const lastQaHostId =
-    modeState.mode === 'default' ? modeState.last_qa_host_user_id : null
+    modeState.mode === 'default' && lastQaSectionMatches
+      ? modeState.last_qa_host_user_id
+      : null
 
   const [posts, unreadMe, qaQuestionsRaw, lastQaQuestionsRaw, viewerIsAdmin] =
     await Promise.all([

--- a/src/components/screen/ScreenAdminBar.tsx
+++ b/src/components/screen/ScreenAdminBar.tsx
@@ -10,7 +10,6 @@ import {
   exitScreenModeAction,
   startLotteryAction,
 } from '@/lib/actions/event-state'
-import { markAllCurrentQaAnsweredAction } from '@/lib/actions/posts'
 import { SECTIONS, isSectionId, type SectionId } from '@/lib/sections'
 import type { ScreenMode } from '@/lib/types'
 import type { VipForDropdown } from '@/lib/queries/event-state'
@@ -84,15 +83,6 @@ export function ScreenAdminBar({ currentSection, screenMode, qaHostUserId, vips 
         must_have_posted: mustHavePosted,
         exclude_previous_winners: excludePreviousWinners,
       })
-      if (res.error) setError(res.error)
-    })
-  }
-
-  function markAllAnswered() {
-    if (!window.confirm('把当前 QA 所有未答问题都标为已答？大屏会清空。')) return
-    setError(null)
-    startTransition(async () => {
-      const res = await markAllCurrentQaAnsweredAction()
       if (res.error) setError(res.error)
     })
   }
@@ -203,14 +193,9 @@ export function ScreenAdminBar({ currentSection, screenMode, qaHostUserId, vips 
           ) : (
             <div className="space-y-1.5">
               {screenMode === 'qa' && (
-                <button
-                  type="button"
-                  onClick={markAllAnswered}
-                  disabled={pending}
-                  className="w-full rounded-md border border-zinc-600 bg-zinc-800 px-2 py-1.5 text-xs font-medium text-zinc-100 hover:bg-zinc-700 disabled:opacity-50"
-                >
-                  全部标已答（清空大屏）
-                </button>
+                <p className="text-[11px] leading-relaxed text-zinc-400">
+                  问题已答 → 鼠标移到问题卡片右上角 ✓ 单条标记。
+                </p>
               )}
               <button
                 type="button"

--- a/src/components/screen/ScreenView.tsx
+++ b/src/components/screen/ScreenView.tsx
@@ -1,11 +1,13 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, useTransition } from 'react'
+import { Check } from 'lucide-react'
 import type { FeedPost } from '@/lib/queries/posts'
 import type { ScreenQuestion } from '@/lib/queries/questions'
 import type { ScreenLotteryDraw } from '@/lib/queries/lottery'
 import type { ScreenModeState } from '@/lib/queries/event-state'
 import { fetchScreenData } from '@/lib/actions/screen'
+import { setQuestionAnsweredAction } from '@/lib/actions/posts'
 import { getBrowserSupabase } from '@/lib/supabase/client'
 import { sectionLabel, SECTION_META, type SectionId } from '@/lib/sections'
 import { displayName, displayMeta } from '@/lib/display'
@@ -148,7 +150,14 @@ export function ScreenView({
 
       <main className="mx-auto w-full max-w-[1600px] flex-1 overflow-hidden px-10 pb-6">
         {slot.kind === 'qa' ? (
-          <QaSlot mode={mode} questions={questions} qrSlot={qrSlot} password={password} />
+          // key 包含当前 host — 切轮次时 QaSlot 整个 remount，乐观隐藏 set 自动重置。
+          <QaSlot
+            key={mode.qa_host_user_id ?? 'no-host'}
+            mode={mode}
+            questions={questions}
+            qrSlot={qrSlot}
+            password={password}
+          />
         ) : slot.kind === 'lottery' ? (
           <LotterySlot draw={slot.draw} now={now} />
         ) : slot.kind === 'poll' ? (
@@ -441,8 +450,25 @@ function QaSlot({
   password: string
 }) {
   const hostName = mode.qa_host_name ?? '嘉宾'
-  const top = questions.slice(0, 5)
-  const ticker = questions.slice(5, 13)
+  // 乐观隐藏：admin 点完「✓」后立刻从大屏移除，无需等 Realtime 回灌。
+  // 父组件用 key={qa_host_user_id} 保证切轮次时 QaSlot remount，set 自动重置。
+  const [answeredIds, setAnsweredIds] = useState<Set<number>>(new Set())
+  const visible = questions.filter((q) => !answeredIds.has(q.id))
+  const top = visible.slice(0, 5)
+  const ticker = visible.slice(5, 13)
+  const [, startTransition] = useTransition()
+
+  function markAnswered(id: number) {
+    setAnsweredIds((s) => new Set(s).add(id))
+    startTransition(async () => {
+      const res = await setQuestionAnsweredAction(id, true)
+      if (res?.error) {
+        // 服务器拒了；不强制 rollback，避免与 Realtime 竞态 — 下一轮
+        // refresh 重新拉到原始 unanswered 列表后会自动出现。
+        console.error('mark answered failed:', res.error)
+      }
+    })
+  }
 
   return (
     <div className="grid h-full grid-cols-[1.1fr_1.4fr] gap-8">
@@ -476,9 +502,9 @@ function QaSlot({
       {/* Right: 问题列表 */}
       <div className="flex h-full min-h-0 flex-col gap-4">
         <p className="text-sm uppercase tracking-[0.18em] text-zinc-500">
-          观众提问 · 共 {questions.length} 条 · 按点赞排序
+          观众提问 · 共 {visible.length} 条 · 按点赞排序
         </p>
-        {questions.length === 0 ? (
+        {visible.length === 0 ? (
           <div className="flex flex-1 items-center justify-center rounded-2xl bg-zinc-900/40 ring-1 ring-zinc-800/60">
             <p className="text-2xl text-zinc-500">还没有人提问，扫码抢沙发 →</p>
           </div>
@@ -488,7 +514,7 @@ function QaSlot({
               {top.map((q, i) => (
                 <li
                   key={q.id}
-                  className="flex gap-4 rounded-2xl bg-zinc-900 px-6 py-4 ring-1 ring-zinc-800"
+                  className="group flex gap-4 rounded-2xl bg-zinc-900 px-6 py-4 ring-1 ring-zinc-800"
                 >
                   <span className="shrink-0 text-3xl font-bold tabular-nums text-zinc-600">
                     {i + 1}
@@ -507,6 +533,17 @@ function QaSlot({
                       </span>
                     </p>
                   </div>
+                  {/* admin 点选「这条已答」— /screen 已 admin-only，不会泄漏给观众。
+                      hover 时显眼一点，平时低存在感避免投影时干扰观看。 */}
+                  <button
+                    type="button"
+                    onClick={() => markAnswered(q.id)}
+                    aria-label="标记已答"
+                    title="标记已答"
+                    className="shrink-0 self-start rounded-lg p-2 text-zinc-600 opacity-50 transition-all hover:bg-emerald-500/20 hover:text-emerald-300 hover:opacity-100 group-hover:opacity-100"
+                  >
+                    <Check className="size-6" aria-hidden />
+                  </button>
                 </li>
               ))}
             </ul>
@@ -517,9 +554,18 @@ function QaSlot({
                 </p>
                 <ul className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm text-zinc-300">
                   {ticker.map((q) => (
-                    <li key={q.id} className="flex items-center gap-2 truncate">
+                    <li key={q.id} className="group flex items-center gap-2 truncate">
                       <span className="shrink-0 text-xs text-rose-400">❤{q.like_count}</span>
                       <span className="truncate">{q.body}</span>
+                      <button
+                        type="button"
+                        onClick={() => markAnswered(q.id)}
+                        aria-label="标记已答"
+                        title="标记已答"
+                        className="ml-auto shrink-0 rounded p-1 text-zinc-600 opacity-0 transition-all hover:bg-emerald-500/20 hover:text-emerald-300 group-hover:opacity-100"
+                      >
+                        <Check className="size-3.5" aria-hidden />
+                      </button>
                     </li>
                   ))}
                 </ul>

--- a/src/lib/actions/event-state.ts
+++ b/src/lib/actions/event-state.ts
@@ -5,6 +5,7 @@ import { getServerSupabase } from '@/lib/supabase/server'
 import { readAdminCookie } from '@/lib/identity'
 import { isSectionId, type SectionId } from '@/lib/sections'
 import { EVENT_END_ISO } from '@/lib/constants'
+import { getCurrentSection } from '@/lib/queries/event-state'
 
 // 主办方手动覆写当前板块。覆写有效期延伸到活动结束（一般主办方一场切一次就走人）。
 // 鉴权：admin cookie。
@@ -72,11 +73,16 @@ export async function startQaAction(
   if (hostErr) return { error: hostErr.message }
   if (!host || !host.is_vip) return { error: '该用户不是嘉宾' }
 
+  // 把当前 LIVE section 快照成 qa_section，绑定本轮 QA。
+  // 没有 LIVE section（活动外 / 空档期）时为 null — /feed 退化为「所有 section 下都显示」。
+  const qaSection = await getCurrentSection()
+
   const { error } = await sb
     .from('event_state')
     .update({
       screen_mode: 'qa',
       qa_host_user_id: hostUserId,
+      qa_section: qaSection,
       lottery_draw_id: null,
       updated_at: new Date().toISOString(),
     })
@@ -89,7 +95,7 @@ export async function startQaAction(
 }
 
 // 退出 QA / lottery，回到 default 骨架。
-// QA 结束时把当前 host 搬到 last_qa_host_user_id，给 /feed「上一轮 QA」
+// QA 结束时把当前 host + section 搬到 last_qa_*，给 /feed「上一轮 QA」
 // 塌陷区块用。lottery 结束不做归档（中奖人由 lottery_draws 表保留）。
 export async function exitScreenModeAction(): Promise<{ error: string | null }> {
   if (!(await readAdminCookie())) return { error: '未授权' }
@@ -97,18 +103,20 @@ export async function exitScreenModeAction(): Promise<{ error: string | null }> 
   const sb = getServerSupabase()
   const { data: cur } = await sb
     .from('event_state')
-    .select('screen_mode, qa_host_user_id')
+    .select('screen_mode, qa_host_user_id, qa_section')
     .eq('id', 1)
     .maybeSingle()
 
   const updates: Record<string, unknown> = {
     screen_mode: 'default',
     qa_host_user_id: null,
+    qa_section: null,
     lottery_draw_id: null,
     updated_at: new Date().toISOString(),
   }
   if (cur?.screen_mode === 'qa' && cur.qa_host_user_id) {
     updates.last_qa_host_user_id = cur.qa_host_user_id
+    updates.last_qa_section = cur.qa_section ?? null
   }
 
   const { error } = await sb.from('event_state').update(updates).eq('id', 1)
@@ -191,6 +199,7 @@ export async function startLotteryAction(
     .update({
       screen_mode: 'lottery',
       qa_host_user_id: null,
+      qa_section: null,
       lottery_draw_id: draw.id,
       updated_at: new Date().toISOString(),
     })

--- a/src/lib/actions/posts.ts
+++ b/src/lib/actions/posts.ts
@@ -136,13 +136,15 @@ export async function createQuestionAction(
 
   const { data: state, error: stateErr } = await sb
     .from('event_state')
-    .select('screen_mode, qa_host_user_id')
+    .select('screen_mode, qa_host_user_id, qa_section')
     .eq('id', 1)
     .maybeSingle()
   if (stateErr) return { error: stateErr.message }
   if (!state || state.screen_mode !== 'qa' || !state.qa_host_user_id) {
     return { error: 'QA 已经结束了' }
   }
+  // qa_section 是 startQa 时快照的板块；空表示不绑定（活动外启动）。
+  const questionSection = isSectionId(state.qa_section) ? state.qa_section : null
 
   // Identity updates: nickname / company optional; questions are usually
   // posted with whatever identity the user has. Match createPostAction's
@@ -162,7 +164,7 @@ export async function createQuestionAction(
     body,
     tags: [],
     show_contact: false,
-    section: null,
+    section: questionSection,
     question_target_user_id: state.qa_host_user_id,
   })
   if (error) return { error: error.message }
@@ -193,32 +195,6 @@ export async function setQuestionAnsweredAction(
 
   if (error) return { error: error.message }
   if (!data) return { error: '没找到这条提问' }
-
-  revalidatePath('/feed')
-  revalidatePath('/screen')
-  return { error: null }
-}
-
-// 批量标记当前 QA host 的所有未答问题为已答 — 切换轮次时清场。
-export async function markAllCurrentQaAnsweredAction(): Promise<PostMutationResult> {
-  if (!(await readAdminCookie())) return { error: '未授权' }
-
-  const sb = getServerSupabase()
-  const { data: state } = await sb
-    .from('event_state')
-    .select('qa_host_user_id')
-    .eq('id', 1)
-    .maybeSingle()
-  if (!state?.qa_host_user_id) return { error: '当前没有进行中的 QA' }
-
-  const { error } = await sb
-    .from('posts')
-    .update({ answered_at: new Date().toISOString() })
-    .eq('type', 'question')
-    .eq('question_target_user_id', state.qa_host_user_id)
-    .is('answered_at', null)
-
-  if (error) return { error: error.message }
 
   revalidatePath('/feed')
   revalidatePath('/screen')

--- a/src/lib/queries/event-state.ts
+++ b/src/lib/queries/event-state.ts
@@ -29,10 +29,13 @@ export type ScreenModeState = {
   qa_host_user_id: string | null
   qa_host_name: string | null
   qa_host_title: string | null
+  // 本轮 QA 绑定的板块（startQa 时快照 LIVE section）；null = 不绑定。
+  qa_section: SectionId | null
   // 上一轮 QA 的 host（exit 时归档），给 /feed 塌陷区块用；
   // 当 mode='qa' 时这俩字段不应该被用（用 qa_host_* 即可）。
   last_qa_host_user_id: string | null
   last_qa_host_name: string | null
+  last_qa_section: SectionId | null
   lottery_draw_id: number | null
 }
 
@@ -42,7 +45,8 @@ export async function getScreenModeState(): Promise<ScreenModeState> {
   const { data } = await sb
     .from('event_state')
     .select(
-      `screen_mode, qa_host_user_id, last_qa_host_user_id, lottery_draw_id,
+      `screen_mode, qa_host_user_id, qa_section,
+       last_qa_host_user_id, last_qa_section, lottery_draw_id,
        host:users!qa_host_user_id ( vip_name, nickname, vip_title, company ),
        last_host:users!last_qa_host_user_id ( vip_name, nickname )`,
     )
@@ -55,8 +59,10 @@ export async function getScreenModeState(): Promise<ScreenModeState> {
       qa_host_user_id: null,
       qa_host_name: null,
       qa_host_title: null,
+      qa_section: null,
       last_qa_host_user_id: null,
       last_qa_host_name: null,
+      last_qa_section: null,
       lottery_draw_id: null,
     }
   }
@@ -74,13 +80,17 @@ export async function getScreenModeState(): Promise<ScreenModeState> {
   const lastHost = Array.isArray(lastHostRel) ? lastHostRel[0] ?? null : lastHostRel ?? null
 
   const mode = (data.screen_mode as ScreenMode) ?? 'default'
+  const qaSectionRaw = data.qa_section as string | null
+  const lastQaSectionRaw = data.last_qa_section as string | null
   return {
     mode,
     qa_host_user_id: (data.qa_host_user_id as string | null) ?? null,
     qa_host_name: host ? host.vip_name ?? host.nickname ?? null : null,
     qa_host_title: host ? host.vip_title ?? host.company ?? null : null,
+    qa_section: isSectionId(qaSectionRaw) ? qaSectionRaw : null,
     last_qa_host_user_id: (data.last_qa_host_user_id as string | null) ?? null,
     last_qa_host_name: lastHost ? lastHost.vip_name ?? lastHost.nickname ?? null : null,
+    last_qa_section: isSectionId(lastQaSectionRaw) ? lastQaSectionRaw : null,
     lottery_draw_id: (data.lottery_draw_id as number | null) ?? null,
   }
 }

--- a/supabase/migrations/0019_qa_section.sql
+++ b/supabase/migrations/0019_qa_section.sql
@@ -1,0 +1,33 @@
+-- =====================================================================
+-- 0019_qa_section.sql — QA 与板块绑定（issue #37）
+-- =====================================================================
+-- 目标：QA 模式启动时把当前 LIVE section 快照下来，让该轮 QA 的提问只
+-- 在对应的 section 下出现在 /feed 顶部。否则切到 lounge 也能看到 QA
+-- 提问入口和列表，会让人困惑。
+--
+-- 字段语义：
+--   qa_section       — 当前 QA 绑定的板块；mode='qa' 时由 startQaAction 写入。
+--                      null 表示该轮 QA 不绑定板块（活动外或空档期启动），
+--                      此时退回旧行为（在所有 section 下都可见）。
+--   last_qa_section  — 上一轮 QA 的板块；exitScreenModeAction 归档时写入，
+--                      给 /feed 「上一轮 QA」塌陷区块用。
+--
+-- CHECK 约束与 current_section 保持一致（lounge / p1 / p2 / breakout / panel）。
+--
+-- 不动 publication：event_state 已在 supabase_realtime 里（migration 0015），
+-- 新字段会自动随行 broadcast 给 anon。
+
+alter table event_state add column qa_section text;
+alter table event_state add column last_qa_section text;
+
+alter table event_state add constraint event_state_qa_section_valid
+  check (
+    qa_section is null
+    or qa_section in ('lounge', 'p1', 'p2', 'breakout', 'panel')
+  );
+
+alter table event_state add constraint event_state_last_qa_section_valid
+  check (
+    last_qa_section is null
+    or last_qa_section in ('lounge', 'p1', 'p2', 'breakout', 'panel')
+  );


### PR DESCRIPTION
Closes #37

## Summary
- **QA 与板块绑定**：`startQa` 时把当前 LIVE section 快照进 `event_state.qa_section`；新提问继承该 section；`/feed` 只在查看的 section 与 `qa_section` 匹配时显示 QA 入口与问题列表。`exitScreenMode` 归档进 `last_qa_section`，让「上一轮 QA」塌陷区块沿用同一过滤规则。活动外启动（`qa_section=null`）退化为「所有 section 下都显示」。
- **/screen 单条点击标已答**：QA slot 每条问题加 ✓ 按钮，admin 点击即标记已答（`/screen` 已 admin-only），乐观隐藏 + 服务器回写。切 host 时 QaSlot 通过 `key` remount 自动重置乐观集合。删掉控制台「全部标已答（清空大屏）」一键按钮以及对应 server action，统一走单条点选避免误清场。

## Migration
- `0019_qa_section.sql` — `event_state` 加 `qa_section` / `last_qa_section`（CHECK 与 `current_section` 一致：`lounge / p1 / p2 / breakout / panel`）。
- `event_state` 已在 `supabase_realtime` publication（migration 0015），新字段会自动随行 broadcast，不需要 Dashboard toggle。

## Test plan
- [ ] 应用 migration 0019 到生产 DB
- [ ] /screen 控制台开 QA（host=某 VIP），当前 LIVE 是 p1：在 /feed?section=p1 看到 QA 入口；切到 lounge / p2 / breakout / panel 不再看到
- [ ] /feed?section=p1 提问 → 大屏 QA slot 收到该提问
- [ ] /screen 上鼠标 hover 到问题卡片右上 ✓ → 点击 → 该条立刻消失，DB `posts.answered_at` 已写
- [ ] 退出 QA → /feed?section=p1 显示「上一轮 QA · 向 X · n 个问题」塌陷；切到其他 section 不显示
- [ ] 控制台「主办方控制台」面板里不再有「全部标已答」按钮，QA 期间显示一行「鼠标移到问题卡片右上角 ✓ 单条标记」提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)