### PR TITLE
feat(consent): AI 撮合显式同意 (issue #34)

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -150,6 +150,7 @@ export default async function FeedPage({ searchParams }: { searchParams: SearchP
             vipName={user.vip_name}
             vipTitle={user.vip_title}
             section={section}
+            aiConsentGiven={!!user.ai_consent_at}
           />
 
           {posts.length === 0 ? (

--- a/src/components/PostComposer.tsx
+++ b/src/components/PostComposer.tsx
@@ -18,6 +18,10 @@ type Props = {
   vipName: string | null
   vipTitle: string | null
   section: SectionId
+  // issue #34: 用户是否已同意把内容发给 DeepSeek 处理。
+  // false → 在 AI 撮合 box 里追加一个 checkbox，必须勾选才能发送 intent。
+  // true  → checkbox 不渲染，已是常态。
+  aiConsentGiven: boolean
 }
 
 // IMPORTANT: textareas here are intentionally uncontrolled.
@@ -45,6 +49,7 @@ export function PostComposer({
   vipName,
   vipTitle,
   section,
+  aiConsentGiven,
 }: Props) {
   const [state, formAction, isPending] = useActionState(createPostAction, initial)
   const [identityOpen, setIdentityOpen] = useState(false)
@@ -214,6 +219,19 @@ export function PostComposer({
               <span className={matchRemaining < 0 ? 'text-red-600' : ''}>{matchRemaining}</span>
             </div>
           </div>
+          {!aiConsentGiven && (
+            <label className="flex cursor-pointer items-start gap-2 rounded-md border border-blue-300 bg-white/80 px-2.5 py-2 text-[12px] text-blue-900">
+              <input
+                type="checkbox"
+                name="ai_consent"
+                className="mt-0.5 size-4 shrink-0 accent-blue-600"
+              />
+              <span>
+                我同意把<span className="font-medium">这条需求</span>以及我在此次活动里的
+                <span className="font-medium">公开发帖</span>发给 DeepSeek API 处理（用于撮合）。同意一次后不再询问。
+              </span>
+            </label>
+          )}
         </div>
       )}
 

--- a/src/lib/actions/posts.ts
+++ b/src/lib/actions/posts.ts
@@ -32,6 +32,14 @@ export async function createPostAction(
     return { error: `撮合需求不能超过 ${MATCH_INTENT_MAX_CHARS} 字` }
   }
   const matchIntent = matchIntentRaw.length > 0 ? matchIntentRaw : null
+  const aiConsentTicked = formData.get('ai_consent') === 'on'
+
+  // Consent gate (issue #34): match_intent only persists if the user has
+  // already consented OR is consenting on this submit via the ai_consent
+  // checkbox. No silent drops — surface a clear error so user can retry.
+  if (matchIntent && !user.ai_consent_at && !aiConsentTicked) {
+    return { error: '需要先勾选「同意把内容发给 DeepSeek 处理」才能委托 AI 撮合' }
+  }
 
   const sectionRaw = formData.get('section')
   const section = isSectionId(sectionRaw) ? sectionRaw : null
@@ -43,6 +51,12 @@ export async function createPostAction(
   if (nickname !== undefined) updates.nickname = nickname
   if (company !== undefined) updates.company = company
   if (contactHandle !== undefined) updates.contact_handle = contactHandle
+  // Grant consent inline only when actually using AI matching (matchIntent
+  // present). Ticking the checkbox without sending intent is a no-op — keeps
+  // the example behavior: 拒绝过的话再次发消息会再次询问.
+  if (matchIntent && aiConsentTicked && !user.ai_consent_at) {
+    updates.ai_consent_at = new Date().toISOString()
+  }
   await sb.from('users').update(updates).eq('id', user.id)
 
   const { data: inserted, error } = await sb

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,7 @@ export type UserRow = {
   created_at: string
   last_seen_at: string
   last_seen_me_at: string
+  ai_consent_at: string | null
 }
 
 export type PollOption = { id: number; label: string }

--- a/supabase/functions/match/index.ts
+++ b/supabase/functions/match/index.ts
@@ -152,9 +152,15 @@ async function fetchCandidates(supabase: SupabaseClient): Promise<CandidatePost[
 }
 
 async function fetchProfiles(supabase: SupabaseClient) {
+  // issue #34: 只聚合已同意 AI 处理的用户的帖子。inner join + filter 保证
+  // 未同意者整片画像不进 prompt。candidates 路径无需重复 gate —
+  // intent 写入端（createPostAction）已经卡住未同意者。
   const { data, error } = await supabase
     .from('posts')
-    .select('user_id, body, tags, section, users:user_id (id, nickname, company, is_vip, vip_name, vip_title)')
+    .select(
+      'user_id, body, tags, section, users:user_id!inner (id, nickname, company, is_vip, vip_name, vip_title, ai_consent_at)',
+    )
+    .not('users.ai_consent_at', 'is', null)
     .order('created_at', { ascending: false })
     .limit(PROFILES_POST_LIMIT)
   if (error) throw new Error(`profiles query: ${error.message}`)

--- a/supabase/migrations/0019_ai_consent.sql
+++ b/supabase/migrations/0019_ai_consent.sql
@@ -1,0 +1,20 @@
+-- =====================================================================
+-- 0019_ai_consent.sql — 用户对「把内容发给 DeepSeek 撮合」的显式同意（issue #34）
+-- =====================================================================
+-- 单列即可覆盖两路数据：
+--   1) 自己的私下需求（post_match_intents.intent）
+--   2) 自己的公开发帖被聚合成画像，供 AI 给别人推荐
+-- 因为用户委托 AI 找人 = 必然也得贡献画像供反向匹配，两件事不可分割。
+--
+-- 语义：
+--   null         → 从未决定。UI 在用户首次点「委托 AI 撮合」时弹询问。
+--   not null     → 已同意，永不再问；时间戳供审计。
+--   拒绝         → 不写库（example 行为：下次再问）。
+--
+-- 后端两路守卫均依赖此列：
+--   - createPostAction：写 post_match_intents 前 double-check。
+--   - supabase/functions/match：fetchProfiles 过滤未同意者；
+--     fetchCandidates 因 intent 写入已被 gate，无需重复过滤。
+
+alter table users
+  add column if not exists ai_consent_at timestamptz;


### PR DESCRIPTION
Closes #34

## Summary
- 给 AI 撮合两路数据加显式 consent gate：(1) 你的公开发帖被聚合成画像发 DeepSeek，(2) 你填的私下需求发 DeepSeek
- 一个 consent 同时管两件事 —— 委托 AI 找人 = 必然贡献画像才能被反向推荐，拆开徒增认知负担
- 行为对齐 issue 例子：同意一次永久记住，拒绝（关 box / 不勾）不写库 → 下次再用 AI 时仍要勾

## 改动
- `migration 0019` — `users.ai_consent_at timestamptz`（null=未决定，非空=已同意）
- `PostComposer` — `aiConsentGiven=false` 时在 AI 撮合 box 末尾加 checkbox；true 时不渲染（已是常态）
- `createPostAction` — `match_intent` 非空 + 未同意 + 未勾 checkbox → 报错（不静默丢用户输入）；勾了则同时落 consent + intent
- `fetchProfiles`（edge function）— inner join + `not is null` 过滤未同意者
- candidates 路径无需再 gate：intent 写入端已经卡住

## 已就绪
- migration 已应用到 dev DB
- match edge function 已重新部署
- `tsc --noEmit` + `eslint src` 全 green

## Test plan
- [ ] 新身份打开 /feed → 点「委托 AI 撮合」→ box 末尾出现 checkbox
- [ ] 填 intent + 不勾 → 报错，post 没发
- [ ] 填 intent + 勾上 → post 发出，`users.ai_consent_at` 写入
- [ ] 再次发帖时 box 不再出现 checkbox
- [ ] 拒绝场景：不勾 + 关 box + 仅发普通帖 → 正常发，consent 仍为 null
- [ ] DB 端：未同意者的帖子不会出现在下一轮 match_runs 的 prompt 里