### PR TITLE
fix(screen): 兜底刷新 60s → 15s + diag 真测 poll_votes (#36)

### DIFF
--- a/scripts/diag-realtime.mjs
+++ b/scripts/diag-realtime.mjs
@@ -36,6 +36,7 @@ const events = []
 async function cleanup() {
   if (postId) {
     await srv.from('post_match_intents').delete().eq('post_id', postId)
+    await srv.from('poll_votes').delete().eq('post_id', postId)
     await srv.from('likes').delete().eq('post_id', postId)
     await srv.from('replies').delete().eq('post_id', postId)
     await srv.from('posts').delete().eq('id', postId)
@@ -84,9 +85,20 @@ async function main() {
 
   console.log('Inserting test data into posts / likes / replies / poll_votes …')
 
+  // Use type='poll' so we can also test poll_votes broadcast in the same run
+  // (issue #36: 改投后 /screen 没刷新 — 需要确认 poll_votes Realtime 没断)。
   const p = await srv
     .from('posts')
-    .insert({ user_id: userId, type: 'text', body: 'diag-test' })
+    .insert({
+      user_id: userId,
+      type: 'poll',
+      body: 'diag-test',
+      section: 'lounge',
+      poll_options: [{ id: 1, label: 'A' }, { id: 2, label: 'B' }],
+      poll_multi: false,
+      poll_deadline: '2030-01-01T00:00:00Z',
+      poll_hide_results: false,
+    })
     .select('id')
     .single()
   if (p.error) {
@@ -109,6 +121,16 @@ async function main() {
       .from('replies')
       .insert({ post_id: postId, user_id: userId, body: 'diag-reply' })
     console.log('  replies insert', replyRes.error ? 'FAIL: ' + replyRes.error.message : 'ok')
+
+    // poll_votes：模拟"投票 → 改投"完整链路（INSERT + DELETE + INSERT）
+    const voteIns = await srv.from('poll_votes').insert({ user_id: userId, post_id: postId, option_id: 1 })
+    console.log('  poll_votes insert (initial)', voteIns.error ? 'FAIL: ' + voteIns.error.message : 'ok')
+
+    const voteDel = await srv.from('poll_votes').delete().eq('post_id', postId).eq('user_id', userId)
+    console.log('  poll_votes delete (revote step 1)', voteDel.error ? 'FAIL: ' + voteDel.error.message : 'ok')
+
+    const voteIns2 = await srv.from('poll_votes').insert({ user_id: userId, post_id: postId, option_id: 2 })
+    console.log('  poll_votes insert (revote step 2)', voteIns2.error ? 'FAIL: ' + voteIns2.error.message : 'ok')
   }
 
   console.log(`Listening for ${RUN_MS / 1000}s… any incoming broadcast will be logged above.`)

--- a/src/components/screen/ScreenView.tsx
+++ b/src/components/screen/ScreenView.tsx
@@ -15,7 +15,12 @@ import { Avatar } from '@/components/Avatar'
 const POLL_TICK_MS = 1_000 // ui re-render cadence
 // Safety-net resync if the websocket drops silently — projection mode runs
 // unattended for hours. Realtime events are the primary trigger.
-const FALLBACK_REFRESH_MS = 60_000
+//
+// 15s 的依据（issue #36）：投票实时计数 — 改投后大屏在 30s 一格的轮播里，
+// 即使 Realtime 偶尔丢一次 broadcast，最坏情况下用户也只能等 60s 才看到更
+// 新过的票数 → 给人"改投失效"的错觉。15s 的兜底 + Realtime 主路 + 500ms
+// debounce 一起，把最坏延迟从 60s 压到 15s，刷新成本对 Supabase 可以忽略。
+const FALLBACK_REFRESH_MS = 15_000
 const REALTIME_DEBOUNCE_MS = 500
 const SLOT_MS = 30_000 // each poll slot
 


### PR DESCRIPTION
Closes #36

## 调查过程

issue #36 报"改投后 /screen 没更新 + 投票只在 /me 看到"。直接拿 prod 数据 + 实测脚本验证：

| 假设 | 验证结果 |
|---|---|
| DB 改投没写进去 | ❌ 已写入 — poll #42 (`section=p2`, multi=true) 第一次 4 票 → 改投 3 票，DB 一致 |
| `poll_votes` 没在 publication / Realtime 不广播 | ❌ Realtime 正常 — 用 anon key 跑 `scripts/diag-realtime.mjs` 实测，poll_votes 的 INSERT 和 DELETE 都收到 broadcast |
| 60s 兜底叠加 30s slot 轮播太长 | ✅ 是这个 — Realtime 偶发丢消息时（手机网络抖动/WS 短暂断），用户最坏要等 30~60s 才看到新票数，体感像"改投失效" |
| 投票真的没进 /feed | ❌ poll #42 在 `/feed?section=p2` 查询里能正常返回 |

## 改动

### 1. `FALLBACK_REFRESH_MS` 60s → 15s

Realtime 仍是主路（500ms debounce 就能拿到新数据），15s 只是丢消息时的安全网。每次 refresh 多 5 个 Supabase select，4h 活动 ~1500 次刷新，开销忽略不计。

### 2. `scripts/diag-realtime.mjs` 真测 poll_votes

之前注释里写"测 poll_votes"但实际只插了 posts/likes/replies。现在补上完整链路：
- 把测试帖类型从 text 改成 poll
- 加 INSERT → DELETE → INSERT 三步（模拟改投）
- cleanup 加上 poll_votes 清理

未来怀疑 Realtime 出问题时可以直接重跑。

## issue #36 第二部分

> 另外，投票只出现在"我"下面。feed下面看不到，不知道是不是设计

经过实测：poll #42 (`section=p2`) 在 `/feed?section=p2` 是可见的。最可能的原因是 admin 后来清掉了 `event_state.current_section` 覆写（DB 现在是 null），导致 `/feed` 没有 query 时默认跳到 `lounge`，看不到 p2 板块的帖子。

**这是当前 section 设计的预期行为** — 每条帖子归属一个板块，只有切到对应 tab 才看得到。本 PR 不改。如果想让活动期间所有 section 都默认可见（比如加"全部"tab），可以再开 issue 讨论。

## 测试 plan

- [x] `tsc --noEmit` 通过
- [x] `eslint src/components/screen/ScreenView.tsx` 通过
- [x] `scripts/diag-realtime.mjs` 跑通，全部 5 张表（含 poll_votes INSERT + DELETE）都收到事件
- [ ] 上线后用两个浏览器测：A 窗口 /screen，B 窗口 /feed?section=p2 改投，A 应在 ≤15s 内看到新票数（通常 <1s 通过 Realtime）

🤖 Generated with [Claude Code](https://claude.com/claude-code)